### PR TITLE
fix link to configure.py

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,7 +13,7 @@
 - Download the [latest release](https://ghe.io/gm3dmo/the-power/releases/latest).
 - Unzip the release file to a directory of your choice.
 - Change into the the directory and version of the power.
-- Run [`configure.py`](configure.py) to generate the `.gh-api-examples.conf` file. This file feeds variables to the scripts in The Power.:
+- Run [`configure.py`](/configure.py) to generate the `.gh-api-examples.conf` file. This file feeds variables to the scripts in The Power.:
 
 ```
 $ python3 configure.py


### PR DESCRIPTION
link was pointing at `configure.py`, but because of the relative docs path was pointing at `docs/configure.py` -  prefixed filename with `/` to fix it