### PR TITLE
Add set-actions-oidc-custom-issuer-policy-for-an-enterprise.sh

### DIFF
--- a/set-actions-oidc-custom-issuer-policy-for-an-enterprise.sh
+++ b/set-actions-oidc-custom-issuer-policy-for-an-enterprise.sh
@@ -1,0 +1,25 @@
+. .gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#set-the-github-actions-oidc-custom-issuer-policy-for-an-enterprise
+# PUT /enterprises/{enterprise}/actions/oidc/customization/issuer
+# You must authenticate using an access token with the admin:enterprise scope to use this endpoint. 
+
+include_enterprise_slug=$1
+
+if [ "$include_enterprise_slug" == "true" ]
+then
+    curl ${curl_custom_flags} \
+        -X PUT \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        ${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/issuer -d '{"include_enterprise_slug":true}'
+elif [ "$include_enterprise_slug" == "false" ]
+then
+    curl ${curl_custom_flags} \
+        -X PUT \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        ${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/issuer -d '{"include_enterprise_slug":false}'
+else
+  echo "You must pass either 'true' or 'false' as an argument to this script."
+fi

--- a/set-actions-oidc-custom-issuer-policy-for-an-enterprise.sh
+++ b/set-actions-oidc-custom-issuer-policy-for-an-enterprise.sh
@@ -4,22 +4,19 @@
 # PUT /enterprises/{enterprise}/actions/oidc/customization/issuer
 # You must authenticate using an access token with the admin:enterprise scope to use this endpoint. 
 
-include_enterprise_slug=$1
+# Use $1 or "true" as a default of no argument is provided.
+include_enterprise_slug=${1:-true}
 
-if [ "$include_enterprise_slug" == "true" ]
-then
+json_file=tmp/set-actions-oidc-custom-issuer-policy-for-an-enterprise.json
+
+jq -n \
+           --arg include_enterprise_slug "${include_enterprise_slug}" \
+           '{
+             include_enterprise_slug: $include_enterprise_slug | test("true")
+           }' > ${json_file}
+
     curl ${curl_custom_flags} \
         -X PUT \
         -H "Accept: application/vnd.github.v3+json" \
         -H "Authorization: token ${GITHUB_TOKEN}" \
-        ${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/issuer -d '{"include_enterprise_slug":true}'
-elif [ "$include_enterprise_slug" == "false" ]
-then
-    curl ${curl_custom_flags} \
-        -X PUT \
-        -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        ${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/issuer -d '{"include_enterprise_slug":false}'
-else
-  echo "You must pass either 'true' or 'false' as an argument to this script."
-fi
+i          ${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/issuer  --data @${json_file}


### PR DESCRIPTION
Sets the GitHub Actions OpenID Connect (OIDC) custom issuer policy for an enterprise.

https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#set-the-github-actions-oidc-custom-issuer-policy-for-an-enterprise

Note, passing `include_enterprise_slug` as a boolean value is required. 

