### PR TITLE
Add create-codespace-for-authenticated-user.sh

### DIFF
--- a/create-a-codespace-for-authenciated-user.sh
+++ b/create-a-codespace-for-authenciated-user.sh
@@ -1,0 +1,30 @@
+. .gh-api-examples.conf
+
+# https://docs.github.com/en/rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user
+# POST /user/codespaces
+
+# If the script is passed an argument $1 use that as the repo id
+if [ -z "$1" ]
+  then
+    repository_id=$(./get-a-repo.sh ${repo} | jq -r '.id')
+  else
+    repository_id=$1
+fi
+
+
+json_file=tmp/create-codespace.json
+
+jq -n \
+           --argjson repository_id ${repository_id} \
+           --arg ref "${base_branch}" \
+           '{
+             repository_id : $repository_id,
+             ref : $ref
+           }' > ${json_file}
+
+
+set x
+curl -v ${curl_custom_flags} \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: token ${GITHUB_TOKEN}" \
+     ${GITHUB_API_BASE_URL}/user/codespaces --data @${json_file}


### PR DESCRIPTION
https://docs.github.com/en/rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user

Creates a new codespace, owned by the authenticated user.

This endpoint requires either a repository_id OR a pull_request but not both.

You must authenticate using an access token with the `codespace` scope to use this endpoint.

Created whilst working https://github.zendesk.com/agent/tickets/1817997.