### PR TITLE
GitHub Apps: allow to set an absolute path of `private_pem_file`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -183,6 +183,13 @@ default_deployment_id=1
 ### [GitHub Apps](https://docs.github.com/en/rest/apps)
 # https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
 # Set private_pem_file name to the private key you've generated and downloaded..
+#
+# If you set a relative path, it is regarded as a relative path from your home directory.
+#
+# For example:
+#   private_pem_file=Downloads/testapp.YYYY-MM-DD.private-key.pem
+#   #=> The absolute path of the pem file is $HOME/Downloads/testapp.YYYY-MM-DD.private-key.pem
+#
 private_pem_file=${private_key_pem_file}
 # When working with the power in a codespace you may need a path like:
 #private_pem_file=../../workspaces/the-power/ft-testapp.2022-03-23.private-key.pem

--- a/tiny-get-jwt.rb
+++ b/tiny-get-jwt.rb
@@ -1,10 +1,22 @@
 require 'openssl'
 require 'jwt'  # https://rubygems.org/gems/jwt
-
+require 'pathname'
 
 private_pem_name = ARGV[0]
+private_pem = if Pathname.new(private_pem_name).absolute?
+                File.read(private_pem_name)
+              else
+                warn <<EOM
+In .gh-api-examples.conf, a relative path is set to private_pem_file.
 
-private_pem = File.read("#{Dir.home}/#{private_pem_name}")
+   #{private_pem_name}
+
+It is regarded as a relative path from your home directory, but it is recommended to set an absolute path to avoid confusion.
+
+   #{ENV.fetch("HOME")}/#{private_pem_name}
+EOM
+                File.read("#{Dir.home}/#{private_pem_name}")
+              end
 private_key = OpenSSL::PKey::RSA.new(private_pem)
 
 


### PR DESCRIPTION
Hi @gm3dmo 

I sometimes get confused with the `private_pem_file` in *.gh-api-examples.conf*: absolute path vs relative path.

Many times, when I run *tiny-app-or-pat.sh*, *tiny-dump-app-token.sh*, or any other GitHub Apps related scripts, I got error like this:

```
tiny-get-jwt.rb:7:in `read': No such file or directory @ rb_sysopen - /Users/kyanny//Users/kyanny/Downloads/kyanny-test-gradle-zd-1896470.2022-12-01.private-key.pem (Errno::ENOENT)
	from tiny-get-jwt.rb:7:in `<main>'
```

That's because *tiny-get-jwt.rb* always prepend the home directory path, so that setting an absolute path to `private_pem_file` does not work.

However, I believe if an absolute path is acceptable, it is very convenient and easy to understand. So I made *tiny-get-jwt.rb* script a little smarter.

*tiny-get-jwt.rb* checks if an absolute path is set to `private_pem_file`. If the given path is absolute, it accepts it as-is and do not prepend the home directory path.

If the given path is relative, it maintains current behavior: prepend the home directory path. I want to keep it backward compatible because existent users of the-power might be unhappy if breaking change is introduced.

In addition to that, I added some comments to *configure.py* to explain the current & new behavior with regard to `private_pem_file`.

Demo with updated *tiny-get-jwt.rb*:

- If we set an absolute path to `private_pem_file`:

```
$ rg ^private_pem_file .gh-api-examples.conf
149:private_pem_file=/Users/kyanny/Downloads/kyanny-test-gradle-zd-1896470.2022-12-01.private-key.pem

$ bash tiny-dump-app-token.sh
=======================================================
Decoded jwt:

{
  "iat": 1669969440,
  "exp": 1669970040,
  "iss": 268118
}
=======================================================
+++++++++++++++++++++++++++++++++++++++++++++
    App token: ghs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+++++++++++++++++++++++++++++++++++++++++++++

```

- If we set a relative path to `private_pem_file`:

```
$ rg ^private_pem_file .gh-api-examples.conf
149:private_pem_file=Downloads/kyanny-test-gradle-zd-1896470.2022-12-01.private-key.pem

$ bash tiny-dump-app-token.sh
In .gh-api-examples.conf, a relative path is set to private_pem_file.

   Downloads/kyanny-test-gradle-zd-1896470.2022-12-01.private-key.pem

It is regarded as a relative path from your home directory, but it is recommended to set an absolute path to avoid confusion.

   /Users/kyanny/Downloads/kyanny-test-gradle-zd-1896470.2022-12-01.private-key.pem
=======================================================
Decoded jwt:

{
  "iat": 1669969509,
  "exp": 1669970109,
  "iss": 268118
}
=======================================================
+++++++++++++++++++++++++++++++++++++++++++++
    App token: ghs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+++++++++++++++++++++++++++++++++++++++++++++

```