### PR TITLE
Create get-a-diff-of-the-dependencies-between-commits.sh

### DIFF
--- a/get-a-diff-of-the-dependencies-between-commits.sh
+++ b/get-a-diff-of-the-dependencies-between-commits.sh
@@ -1,0 +1,33 @@
+. .gh-api-examples.conf
+
+# https://docs.github.com/en/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits
+# GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}
+
+# if argument $1 is passed use that as variable head
+
+if [ -z "$1" ]
+then
+  head=$(./list-commits-on-repo.sh | jq -r '.[0].sha')
+else
+  head="$1"
+fi
+
+# if argument $2 is passed use that as a variable base
+
+if [ -z "$2" ]
+then
+  base="$(./list-commits-on-repo.sh | jq -r '.[-1].sha')"
+else
+  base="$2"
+fi
+
+# format the basehead variable
+
+basehead=(${base}...${head})
+
+# send a request to GitHub API
+
+curl -v ${curl_custom_flags} \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: token ${GITHUB_TOKEN}" \
+     ${GITHUB_API_BASE_URL}/repos/${org}/empty-project/dependency-graph/compare/${basehead}


### PR DESCRIPTION
Add get-a-diff-of-the-dependencies-between-commits.sh which is used to get the diff of the dependency changes between two commits of a repository, based on the changes to the dependency manifests made in those commits. If no variables are provided, query commits API to compare the first and last commits in the response.