### PR TITLE
Fix token_validator in thepower.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -325,7 +325,7 @@ pool_size=10
     else:
         args.token = input(f"Enter Personal Access Token: ")
 
-    assert thepower.token_validator(args.token)
+    assert thepower.token_validator(args.token), "Invalid format: token should have a valid prefix, or should be 40 characters string."
 
 
     if args.org != "":

--- a/thepower.py
+++ b/thepower.py
@@ -24,7 +24,7 @@ import re
 
 def token_validator(token: string):
     token_format_is_valid = False
-    if token.startswith('gh') or token.startswith('github_pat_') or token.length == 40:
+    if token.startswith('gh') or token.startswith('github_pat_') or len(token) == 40:
         token_format_is_valid = True
     return token_format_is_valid
 


### PR DESCRIPTION
Because Python's `'str' object has no attribute 'length'`. Use `len(str)` instead.

Before:

```
$ python3 configure.py
Enter GitHub hostname: api.github.com
Enter Personal Access Token: 0123456789012345678901234567890123456789
Traceback (most recent call last):
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 679, in <module>
    main(args)
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 328, in main
    assert thepower.token_validator(args.token)
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/thepower.py", line 27, in token_validator
    if token.startswith('gh') or token.startswith('github_pat_') or token.length == 40:
AttributeError: 'str' object has no attribute 'length'
```

After:

```
$ python3 configure.py
Enter GitHub hostname: api.github.com
Enter Personal Access Token: 0123456789012345678901234567890123456789
Org = acme
WARNING:root:Requesting webhook from: https://smee.io/new
INFO:root:webhook url is: https://smee.io/22ifk824wj5l43oA
WARNING:root:Opening https://smee.io/22ifk824wj5l43oA in chrome.

Configuration run is complete. Created .gh-api-examples.conf
INFO:__main__:
Configuration run is complete. Created .gh-api-examples.conf

Launching primer command: list-user.sh
INFO:__main__:
Launching primer command: list-user.sh
{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest"
}

=========================================================
INFO:__main__:
=========================================================

```

`token_validator` still works.

```
$ python3 configure.py
Enter GitHub hostname: api.github.com
Enter Personal Access Token: tooshort
Traceback (most recent call last):
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 679, in <module>
    main(args)
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 328, in main
    assert thepower.token_validator(args.token), "Invalid format: token should have a valid prefix, or should be 40 characters string."
AssertionError: Invalid format: token should have a valid prefix, or should be 40 characters string.
```

```
$ python3 configure.py
Enter GitHub hostname: api.github.com
Enter Personal Access Token: too_0123456789012345678901234567890123456789_long
Traceback (most recent call last):
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 679, in <module>
    main(args)
  File "/Users/kyanny/ghq/github.com/gm3dmo/the-power/configure.py", line 328, in main
    assert thepower.token_validator(args.token), "Invalid format: token should have a valid prefix, or should be 40 characters string."
AssertionError: Invalid format: token should have a valid prefix, or should be 40 characters string.
```

Also, add assertion message for convenience.