### PR TITLE
Add script to unarchive a repo

### DIFF
--- a/unarchive-a-repo.sh
+++ b/unarchive-a-repo.sh
@@ -1,0 +1,26 @@
+. .gh-api-examples.conf
+
+# https://docs.github.com/en/rest/repos/repos#update-a-repository
+# PATCH /repos/{owner}/{repo}
+
+json_file=tmp/update-a-repo.json
+datestamp=$(date +%s)
+description="unarchived by an archiving script at timestamp: ${datestamp}"
+
+rm -f ${json_file}
+
+    jq -n \
+           --arg description "${description}" \
+           --arg archived "false" \
+           '{
+             description: $description,
+             archived: $archived
+           }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X PATCH \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+     ${GITHUB_API_BASE_URL}/repos/${org}/${repo} --data @${json_file}
+
+rm -f ${json_file}


### PR DESCRIPTION
Adds this new script after unarchiving a repo has been added to the REST API in December: https://github.blog/changelog/2022-12-13-unarchive-a-repository-via-the-rest-api/

This mirrors the existing `archive-a-repo.sh` but flips `archived` to `false`.