### PR TITLE
Enclose shell variables with double quotes

### DIFF
--- a/dotcom-configure.sh
+++ b/dotcom-configure.sh
@@ -15,24 +15,24 @@ if [ ! -z "$2" ]
     repo=testrepo
 fi
 
-python3 configure.py --hostname ${hostname} \
-                     --enterprise-name ${enterprise_name} \
-                     --org ${org} \
-                     --repo ${repo} \
-                     --token ${github_token} \
-                     --webhook-url ${webhook} \
+python3 configure.py --hostname "${hostname}" \
+                     --enterprise-name "${enterprise_name}" \
+                     --org "${org}" \
+                     --repo "${repo}" \
+                     --token "${github_token}" \
+                     --webhook-url "${webhook}" \
                      --configure-app yes \
-                     --app-id ${app_id} \
-                     --app-client-secret ${app_client_secret} \
-                     --installation-id ${installation_id} \
-                     --client-id ${client_id} \
+                     --app-id "${app_id}" \
+                     --app-client-secret "${app_client_secret}" \
+                     --installation-id "${installation_id}" \
+                     --client-id "${client_id}" \
                      --team-members "${team_members}" \
                      --team-admin "${team_admin}" \
                      --default-committer "${default_committer}" \
-                     --private-pem-file ${private_pem_file} \
-                     --pr-approver-name ${pr_approver_name} \
-                     --pr-approver-token ${pr_approver_token} \
+                     --private-pem-file "${private_pem_file}" \
+                     --pr-approver-name "${pr_approver_name}" \
+                     --pr-approver-token "${pr_approver_token}" \
                      --chrome-profile "${chrome_profile}" \
-                     --x-client-id ${x_client_id} \
-                     --x-client-secret ${x_client_secret} \
+                     --x-client-id "${x_client_id}" \
+                     --x-client-secret "${x_client_secret}" \
                      --default-repo-visibility public


### PR DESCRIPTION
@gm3dmo 

To be shellcheck compliant and to prevent `python3 configure.sh` from halting with `error: argument --ARGUMENT-NAME: expected one argument`.

# Before

```
❯ ./dotcom-configure.sh the-power-dotcom.skeleton
the-power-dotcom.skeleton: line 12: syntax error near unexpected token `newline'
the-power-dotcom.skeleton: line 12: `enterprise_name=<your enterprise name>'
usage: configure.py [-h] [-o ORG] [-b BASE_BRANCH] [-d CONFIGURE_GITHUB_APP] [-a APP_ID] [-i INSTALLATION_ID] [-e CLIENT_ID] [--app-client-secret APP_CLIENT_SECRET] [-u ADMIN_USER] [--admin-password ADMIN_PASSWORD] [--mgmt-password MGMT_PASSWORD]
                    [--mgmt-port MGMT_PORT] [-w WEBHOOK_URL] [--x-client-id X_CLIENT_ID] [--x-client-secret X_CLIENT_SECRET] [--number-of-users NUMBER_OF_USERS_TO_CREATE_ON_GHES] [--runner-version RUNNER_VERSION] [--runner-os RUNNER_OS]
                    [--runner-platform RUNNER_PLATFORM] [-c DOTCOM_CONFIG] [-r REPO_NAME] [-n HOSTNAME] [-t TOKEN] [-l LOGLEVEL] [-p PRIMER] [--team-name TEAM_NAME] [--private-pem-file PRIVATE_PEM_FILE] [--number-of-orgs NUMBER_OF_ORGS]
                    [--number-of-repos NUMBER_OF_REPOS] [--number-of-teams NUMBER_OF_TEAMS] [--number-of-branches NUMBER_OF_BRANCHES] [--team-members TEAM_MEMBERS] [--team-admin TEAM_ADMIN] [--default-committer DEFAULT_COMMITTER] [--allow-auto-merge ALLOW_AUTO_MERGE]
                    [--delete-branch-on-merge DELETE_BRANCH_ON_MERGE] [--enterprise-name ENTERPRISE_NAME] [--pr-approver-token PR_APPROVER_TOKEN] [--pr-approver-name PR_APPROVER_NAME] [--preferred_client PREFERRED_CLIENT] [--custom-curl-flags CURL_CUSTOM_FLAGS]
                    [--preferred_browser PREFERRED_BROWSER] [--preferred_browser_mode PREFERRED_BROWSER_MODE] [--chrome-profile CHROME_PROFILE] [--default-repo-visibility DEFAULT_REPO_VISIBILITY] [--github-api-version GITHUB_API_VERSION]
                    [--http-protocol HTTP_PROTOCOL]
configure.py: error: argument --enterprise-name: expected one argument
```

# After

It falls back to the interactive interface. Just like `python3 configure.py`

```
❯ ./dotcom-configure.sh the-power-dotcom.skeleton
the-power-dotcom.skeleton: line 12: syntax error near unexpected token `newline'
the-power-dotcom.skeleton: line 12: `enterprise_name=<your enterprise name>'
GitHub hostname = api.github.com
Enter Personal Access Token:
```