### PR TITLE
Fix ghe2json.py to work with --ghe-file option

### DIFF
--- a/ghe2json.py
+++ b/ghe2json.py
@@ -169,7 +169,7 @@ with all scopes set). When that's done press the return key twice to proceed:\n"
     print(f"\033[92m")
     print("\n")
     print_progress_bar()
-    print(f"""\n\nConverted Hubot output to "environment.json" file:\n""")
+    print(f"""\n\nConverted Hubot output to "{args.environment_file}" file:\n""")
     with open(args.environment_file, "r") as f:
         j = json.loads(f.read())
         pprint.pprint(j)

--- a/ghe2json.py
+++ b/ghe2json.py
@@ -137,6 +137,7 @@ export PS1="%m %F{yellow}:%1~%f $ "
 
 
 def main(args):
+    text = ""
     if args.ghe_file == False:
         message="""Please paste below the output from gheboot informing you that the
 appliance is ready (optionally paste in a token for an admin user
@@ -151,35 +152,40 @@ with all scopes set). When that's done press the return key twice to proceed:\n"
             else:
                 break
         text = '\n'.join(lines)
-        environment = (thepower.ghe2json(text))
-        with open(args.environment_file, "w") as f:
-            f.write(environment)
+    else:
+        # assume the file exists
+        with open(args.ghe_file, "r") as f:
+            text = f.read()
+
+    environment = (thepower.ghe2json(text))
+    with open(args.environment_file, "w") as f:
+        f.write(environment)
 
 
-        t = generate_template(environment)
-        with open('shell-profile', 'w') as f:
-           f.write(t)
-            
-        print(f"\033[92m")
-        print("\n")
-        print_progress_bar()
-        print(f"""\n\nConverted Hubot output to "environment.json" file:\n""")
-        with open(args.environment_file, "r") as f:
-            j = json.loads(f.read())
-            pprint.pprint(j)
-        print(f"{'='*80}")
-        print("\n")
-        message = """To create a PAT quick. In Chrome Open the developer console (Option + Command J):
+    t = generate_template(environment)
+    with open('shell-profile', 'w') as f:
+        f.write(t)
+        
+    print(f"\033[92m")
+    print("\n")
+    print_progress_bar()
+    print(f"""\n\nConverted Hubot output to "environment.json" file:\n""")
+    with open(args.environment_file, "r") as f:
+        j = json.loads(f.read())
+        pprint.pprint(j)
+    print(f"{'='*80}")
+    print("\n")
+    message = """To create a PAT quick. In Chrome Open the developer console (Option + Command J):
 
  $$('input[type="checkbox"').map(i => i.checked = true)
 
 """
-        print(f"\033[93m\n\n{message}\033[0m\n")  
-        
+    print(f"\033[93m\n\n{message}\033[0m\n")  
+
+
 
 
             
-
 
 
 if __name__ == "__main__":

--- a/thepower.py
+++ b/thepower.py
@@ -41,7 +41,23 @@ def slugify(s):
 
 
 def ghe2json(text, ssh=True):
-    """Converts the text output from gheboot to json"""
+    """Converts the text output from gheboot to json.
+    
+    Example input:
+
+@kyanny
+, Your requested GHES 3.10.3 single-node resources in  australiaeast on azure (named: gheboot-kyanny-1716187058841) true are ready!
+This is a(n) SINGLE-NODE deployment of GHES
+Access the UI at:
+  http://kyanny-mclq08.ghe-test.com
+Access the instance via SSH at:
+  ssh://admin@gheboot-all-kyanny-0-mclq08.ghe-test.com:122
+The instances in this deployment are:
+  gheboot-all-kyanny-0-mclq08.ghe-test.com
+You can get the Management Console and 'ghe-admin' user's password by running:
+ssh -p122 admin@gheboot-all-kyanny-0-mclq08.ghe-test.com -- cat /data/user/common/gheboot-password
+This Server will automatically be terminated on 2024-05-22T06:38:39Z    
+    """
 
     lexer = shlex.shlex(text)
     lexer.whitespace_split = True


### PR DESCRIPTION
@gm3dmo 

`ghe2json.py` accepts `--ghe-file` option but ignores it. This PR addresses it.

# Before

`./ghe2json.py --ghe-file FILE` does nothing.

```
❯ cat input.txt
@kyanny
, Your requested GHES 3.10.3 single-node resources in  australiaeast on azure (named: gheboot-kyanny-1716187058841) true are ready!
This is a(n) SINGLE-NODE deployment of GHES
Access the UI at:
  http://kyanny-mclq08.ghe-test.com
Access the instance via SSH at:
  ssh://admin@gheboot-all-kyanny-0-mclq08.ghe-test.com:122
The instances in this deployment are:
  gheboot-all-kyanny-0-mclq08.ghe-test.com
You can get the Management Console and 'ghe-admin' user's password by running:
ssh -p122 admin@gheboot-all-kyanny-0-mclq08.ghe-test.com -- cat /data/user/common/gheboot-password
This Server will automatically be terminated on 2024-05-22T06:38:39Z
❯ ./ghe2json.py --ghe-file input.txt

❯ jq . environment.json
jq: error: Could not open file environment.json: No such file or directory
```

# After

It generates the environment JSON file from the specified input file.

```
❯ cat input.txt
@kyanny
, Your requested GHES 3.10.3 single-node resources in  australiaeast on azure (named: gheboot-kyanny-1716187058841) true are ready!
This is a(n) SINGLE-NODE deployment of GHES
Access the UI at:
  http://kyanny-mclq08.ghe-test.com
Access the instance via SSH at:
  ssh://admin@gheboot-all-kyanny-0-mclq08.ghe-test.com:122
The instances in this deployment are:
  gheboot-all-kyanny-0-mclq08.ghe-test.com
You can get the Management Console and 'ghe-admin' user's password by running:
ssh -p122 admin@gheboot-all-kyanny-0-mclq08.ghe-test.com -- cat /data/user/common/gheboot-password
This Server will automatically be terminated on 2024-05-22T06:38:39Z
❯ ./ghe2json.py --ghe-file input.txt



Converting Hubot output...
[==================================================] 100.00%

Converted Hubot output to "environment.json" file:

{'admin_password': '********',
 'admin_user': 'ghe-admin',
 'ghes_version': '3.10.3',
 'hostname': 'kyanny-mclq08.ghe-test.com',
 'ip_addresses': [None, None],
 'ip_primary': None,
 'ip_replica': None,
 'mgmt_password': '********',
 'password_recovery': 'ssh -p122 '
                      'admin@gheboot-all-kyanny-0-mclq08.ghe-test.com -- cat '
                      '/data/user/common/gheboot-password',
 'termination_date': '2024-05-22T06:38:39Z',
 'token': '',
 'token_generate_url': 'https://kyanny-mclq08.ghe-test.com/settings/tokens/new'}
================================================================================




To create a PAT quick. In Chrome Open the developer console (Option + Command J):

 $$('input[type="checkbox"').map(i => i.checked = true)




❯ jq . environment.json
{
  "hostname": "kyanny-mclq08.ghe-test.com",
  "password_recovery": "ssh -p122 admin@gheboot-all-kyanny-0-mclq08.ghe-test.com -- cat /data/user/common/gheboot-password",
  "ghes_version": "3.10.3",
  "termination_date": "2024-05-22T06:38:39Z",
  "token": "",
  "mgmt_password": "********",
  "admin_password": "********",
  "ip_addresses": [
    null,
    null
  ],
  "ip_primary": null,
  "ip_replica": null,
  "admin_user": "ghe-admin",
  "token_generate_url": "https://kyanny-mclq08.ghe-test.com/settings/tokens/new"
}
```

This PR includes other minor fixes/comments.