### PR TITLE
make dedicated command blocks

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,9 +3,19 @@
 ### Prerequisites
 * Linux/Mac/GitHub Codespace
 * A GitHub Enterprise Server or dotcom org with a Enterprise admin user name and password 
-* A `jq` command. `brew install jq` on your client.
+* A `jq` command on your client:
+
+```
+brew install jq
+```
+  
 * A Python >3.6 interpreter on your Mac.
-* The [JWT Rubygem](https://rubygems.org/gems/jwt). `sudo gem install jwt` - Required for [GitHub App authentication](https://github.com/gm3dmo/the-power/blob/main/docs/setting-up-a-gh-app.md#using-a-github-app-with-the-power).
+* The [JWT Rubygem](https://rubygems.org/gems/jwt) required for [GitHub App authentication](https://github.com/gm3dmo/the-power/blob/main/docs/setting-up-a-gh-app.md#using-a-github-app-with-the-power):
+
+```
+sudo gem install jwt
+```
+
 * [Create your token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). In GitHub Enterprise (give it all the scopes. Be careful and give the token an expiry date if running on GitHub.com. Strongly recommend a token with short expiry time. If creating a lot of tokens, then this tip for [selecting all checkboxes on](https://gist.github.com/gm3dmo/e085294a622c1c72eec0e8b48d72b092) may be useful.
 
 ### Setup


### PR DESCRIPTION
put installation instructions in full command blocks so they are copyable from the docs.