### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/hookreceiver/hookreceiver.py
+++ b/hookreceiver/hookreceiver.py
@@ -182,7 +182,7 @@ def truncate_events():
         return redirect('/hookdb')
     except Exception as e:
         app.logger.error(f"Failed to truncate events: {str(e)}")
-        return f'Error: {str(e)}', 500
+        return "An internal error occurred", 500
 
 
 @app.route('/hookdb')
@@ -282,7 +282,8 @@ def hookdb():
             formatted_payload=formatted_payload
         )
     except Exception as e:
-        return f"Error loading events: {e}", 500
+        app.logger.error(f"Error loading events: {str(e)}")
+        return "An internal error occurred", 500
 
 
 @app.route('/clear', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/gm3dmo/the-power/security/code-scanning/2](https://github.com/gm3dmo/the-power/security/code-scanning/2)

To fix the issue, we should replace the detailed error message returned to the user with a generic error message. The detailed exception information should be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

Specifically:
1. Replace the response `f'Error: {str(e)}', 500` with a generic message like `"An internal error occurred"`.
2. Ensure that the detailed exception information (`str(e)`) is logged using `app.logger.error` for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
