### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/powerindex/app.py
+++ b/powerindex/app.py
@@ -143,8 +143,17 @@ def get_shell_scripts():
     return [os.path.basename(script) for script in shell_scripts]
 
 def get_script_content(filename):
+    from werkzeug.utils import secure_filename
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    file_path = os.path.join(parent_dir, filename)
+    
+    # Sanitize the filename
+    safe_filename = secure_filename(filename)
+    file_path = os.path.normpath(os.path.join(parent_dir, safe_filename))
+    
+    # Ensure the file path is within the parent directory
+    if not file_path.startswith(parent_dir):
+        return "Error: Access to the requested file is not allowed.", '', ''
+    
     try:
         with open(file_path, 'r') as file:
             content = file.read()


### PR DESCRIPTION
Potential fix for [https://github.com/gm3dmo/the-power/security/code-scanning/6](https://github.com/gm3dmo/the-power/security/code-scanning/6)

To fix the issue, we need to validate the `filename` parameter to ensure it does not allow access to files outside the intended directory. The best approach is to normalize the constructed path using `os.path.normpath` and verify that it resides within the `parent_dir`. If the normalized path does not start with `parent_dir`, we should reject the request.

Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the `filename` and ensure it does not contain any special characters or directory traversal sequences. This provides an extra layer of security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
