### PR TITLE
Replace `client_id` with `app_client_id`

### DIFF
--- a/check-a-token.sh
+++ b/check-a-token.sh
@@ -15,7 +15,7 @@ jq -n \
 
 curl \
      -X POST \
-     --user "${client_id}:${app_client_secret}" \
+     --user "${app_client_id}:${app_client_secret}" \
      --header "X-GitHub-Api-Version: ${github_api_version}" \
-     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}
+     --url "${GITHUB_API_BASE_URL}/applications/${app_client_id}/token" --data @${json_file}
 

--- a/delete-an-app-authorization.sh
+++ b/delete-an-app-authorization.sh
@@ -15,6 +15,6 @@ jq -n \
 
 curl \
      -X DELETE \
-     --user "${client_id}:${app_client_secret}" \
+     --user "${app_client_id}:${app_client_secret}" \
      --header "X-GitHub-Api-Version: ${github_api_version}" \
-     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/grant" --data @${json_file}
+     --url "${GITHUB_API_BASE_URL}/applications/${app_client_id}/grant" --data @${json_file}

--- a/delete-an-app-token.sh
+++ b/delete-an-app-token.sh
@@ -16,6 +16,6 @@ jq -n \
 
 curl \
      -X DELETE \
-     --user "${client_id}:${app_client_secret}" \
+     --user "${app_client_id}:${app_client_secret}" \
      --header "X-GitHub-Api-Version: ${github_api_version}" \
-     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}
+     --url "${GITHUB_API_BASE_URL}/applications/${app_client_id}/token" --data @${json_file}

--- a/ghes-configure.sh
+++ b/ghes-configure.sh
@@ -25,7 +25,7 @@ python3 configure.py --hostname ${hostname} \
                      --configure-app yes \
                      --app-id ${app_id} \
                      --installation-id ${installation_id} \
-                     --client-id ${client_id} \
+                     --client-id ${app_client_id} \
                      --team-members "${team_members}" \
                      --team-admin "${team_admin}" \
                      --default-committer "${default_committer}" \

--- a/oauth-device-flow-step3.sh
+++ b/oauth-device-flow-step3.sh
@@ -23,10 +23,10 @@ echo ========== Step 3: Create step 3 device flow file =======================
 echo
 echo
 jq -n \
-                --arg client_id "${client_id}" \
+                --arg app_client_id "${app_client_id}" \
                 --arg device_code "${device_code}" \
                 --arg grant_type "${grant_type}" \
-                '{ client_id: $client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}
+                '{ client_id: $app_client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}
 cat ${json_file} | jq -r
 echo
 echo ========================================================================

--- a/oauth-device-flow-steps1-and-2.sh
+++ b/oauth-device-flow-steps1-and-2.sh
@@ -9,9 +9,9 @@ step1_response_file=tmp/step1-response.json
 scope="read:enterprise"
 
 jq -n \
-                --arg client_id "${client_id}" \
+                --arg app_client_id "${app_client_id}" \
                 --arg scope  "${scope}" \
-                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}
+                '{ client_id: $app_client_id, scope: $scope  }'  > ${json_file}
 
 echo ========== Step 1: json file for client and scope ======================
 echo 

--- a/oauth-renew-access-token-and-refresh-token.sh
+++ b/oauth-renew-access-token-and-refresh-token.sh
@@ -16,9 +16,9 @@ echo "grant_type: ${grant_type}"
 jq -n \
                 --arg refresh_token "${refresh_token}" \
                 --arg grant_type "${grant_type}" \
-                --arg client_id "${client_id}" \
+                --arg app_client_id "${app_client_id}" \
                 --arg client_secret "${client_secret}" \
-                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $client_id, client_secret: $client_secret }'  > ${json_file}
+                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $app_client_id, client_secret: $client_secret }'  > ${json_file}
 
 cat ${json_file} | jq -r
 

--- a/proxima-configure.sh
+++ b/proxima-configure.sh
@@ -25,7 +25,7 @@ python3 configure.py --hostname "${hostname}" \
                      --app-id "${app_id}" \
                      --app-client-secret "${app_client_secret}" \
                      --installation-id "${installation_id}" \
-                     --client-id "${client_id}" \
+                     --client-id "${app_client_id}" \
                      --team-members "${team_members}" \
                      --team-admin "${team_admin}" \
                      --default-committer "${default_committer}" \

--- a/reset-a-token.sh
+++ b/reset-a-token.sh
@@ -15,7 +15,7 @@ jq -n \
 
 curl \
      -X PATCH \
-     --user "${client_id}:${app_client_secret}" \
+     --user "${app_client_id}:${app_client_secret}" \
      --header "X-GitHub-Api-Version: ${github_api_version}" \
-     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}
+     --url "${GITHUB_API_BASE_URL}/applications/${app_client_id}/token" --data @${json_file}
 

--- a/tiny-github-app-oauth-renew-access-token-and-refresh-token.sh
+++ b/tiny-github-app-oauth-renew-access-token-and-refresh-token.sh
@@ -16,9 +16,9 @@ echo "grant_type: ${grant_type}"
 jq -n \
                 --arg refresh_token "${refresh_token}" \
                 --arg grant_type "${grant_type}" \
-                --arg client_id "${client_id}" \
+                --arg app_client_id "${app_client_id}" \
                 --arg client_secret "${app_client_secret}" \
-                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $client_id, client_secret: $client_secret }'  > ${json_file}
+                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $app_client_id, client_secret: $client_secret }'  > ${json_file}
 
 cat ${json_file} | jq -r
 

--- a/tiny-github-app-oauth-web-application-flow-step1.sh
+++ b/tiny-github-app-oauth-web-application-flow-step1.sh
@@ -16,4 +16,4 @@ then
 fi
 
 
-open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${client_id}"
+open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${app_client_id}"

--- a/tiny-github-app-oauth-web-application-flow-step2.sh
+++ b/tiny-github-app-oauth-web-application-flow-step2.sh
@@ -21,4 +21,4 @@ code=$1
 curl ${curl_custom_flags} -L \
      -H "Accept: application/vnd.github.v3+json" \
      -X POST \
-        "http://${hostname}/login/oauth/access_token?client_id=${client_id}&client_secret=${app_client_secret}&code=${code}" | jq -r
+        "http://${hostname}/login/oauth/access_token?client_id=${app_client_id}&client_secret=${app_client_secret}&code=${code}" | jq -r


### PR DESCRIPTION
Follow up of  #425 and #426.

After #426, `configure.py` no longer generates `.gh-api-example.conf` with `client_id`shell variable definition.

There are shell scripts that refer `$client_id` shell variable. These shell scripts should refer `$app_client_id` instead of `$client_id`.

In this pull request, I replaced `client_id` with `app_client_id` in the shell scripts.

I used the following shell command to list the affected files.

```
rg -P '(?<!_)client_id' *.sh --sort path --heading --color=always
```

This regexp matches `client_id` but does not match `_client_id`, so it should list all lines that haven't updated to `app_client_id` yet.

<details>
<summary>List of files before this pull request (at bdc2f689f08d1d0a0743f32a974d5af4908978fc)</summary>

```
check-a-token.sh
# POST /applications/{client_id}/token
     --user "${client_id}:${app_client_secret}" \
     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}

delete-an-app-authorization.sh
# DELETE /applications/{client_id}/grant
     --user "${client_id}:${app_client_secret}" \
     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/grant" --data @${json_file}

delete-an-app-token.sh
# DELETE /applications/{client_id}/token
     --user "${client_id}:${app_client_secret}" \
     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}

ghes-configure.sh
                     --client-id ${client_id} \

legacy-oauth-check-an-authorization.sh
# GET /applications/{client_id}/tokens/{access_token}
client_id=${x_client_id}
     -u ${client_id}:${client_secret} \
        https://${hostname}/api/v3/applications/${client_id}/tokens/${access_token}

legacy-oauth-create-a-new-authorization.sh
client_id=${x_client_id}
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, client_secret: $client_secret, scopes: [ $scopes ], note: $note, note_url: $note_url, fingerprint: $fingerprint  }'  > ${json_file}
#                '{ client_id: $client_id, client_secret: $client_secret, scopes: [ $scopes ], note: $note, note_url: $note_url, fingerprint: $fingerprint  }'  > ${json_file}
# This set up works but the client_id is not set:

legacy-oauth-delete-an-app-token.sh
# DELETE /applications/{client_id}/token

legacy-oauth-device-flow-step3.sh
                --arg client_id "${x_client_id}" \
                '{ client_id: $client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}

legacy-oauth-device-flow-steps1-and-2.sh
                --arg client_id "${x_client_id}" \
                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}

legacy-oauth-get-or-create-an-authorization-for-a-specific-app-and-fingerprint.sh
# PUT /authorizations/clients/{client_id}/{fingerprint}
client_id=${x_client_id}
        https://${hostname}/api/v3/authorizations/clients/${client_id}/${fingerprint} --data @${json_file}

legacy-oauth-get-or-create-an-authorization-for-a-specific-app.sh
# PUT /authorizations/clients/{client_id}
client_id=${x_client_id}
        https://${hostname}/api/v3/authorizations/clients/${client_id} --data @${json_file}

legacy-oauth-list-your-authorizations.sh
client_id=${x_client_id}
        "${GITHUB_API_BASE_URL}/authorizations?client_id=${client_id}":

legacy-oauth-list-your-grants.sh
# If the script is passed an argument $1 use that as the client_id
    client_id=${x_client_id}
    client_id=$1
        "${GITHUB_API_BASE_URL}/applications/grants?client_id=${client_id}"

legacy-oauth-steps1-and-2.sh
# GitHub Apps already have use of the client_id variable
client_id=${x_client_id}
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}

legacy-oauth-web-application-flow-step1.sh
client_id=${x_client_id}
open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${client_id}&scope=${url_encoded_scope}"

legacy-oauth-web-application-flow-step2.sh
client_id=${x_client_id}
        "http://${hostname}/login/oauth/access_token?client_id=${client_id}&client_secret=${client_secret}&code=${code}" | jq -r

oauth-device-flow-step3.sh
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}

oauth-device-flow-steps1-and-2.sh
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}

oauth-renew-access-token-and-refresh-token.sh
                --arg client_id "${client_id}" \
                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $client_id, client_secret: $client_secret }'  > ${json_file}

proxima-configure.sh
                     --client-id "${client_id}" \

reset-a-token.sh
# PATCH /applications/{client_id}/token
     --user "${client_id}:${app_client_secret}" \
     --url "${GITHUB_API_BASE_URL}/applications/${client_id}/token" --data @${json_file}

tiny-github-app-oauth-renew-access-token-and-refresh-token.sh
                --arg client_id "${client_id}" \
                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $client_id, client_secret: $client_secret }'  > ${json_file}

tiny-github-app-oauth-web-application-flow-step1.sh
open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${client_id}"

tiny-github-app-oauth-web-application-flow-step2.sh
        "http://${hostname}/login/oauth/access_token?client_id=${client_id}&client_secret=${app_client_secret}&code=${code}" | jq -r
```

</details>

<details>
<summary>List of files after this pull request</summary>

```
check-a-token.sh
# POST /applications/{client_id}/token

delete-an-app-authorization.sh
# DELETE /applications/{client_id}/grant

delete-an-app-token.sh
# DELETE /applications/{client_id}/token

legacy-oauth-check-an-authorization.sh
# GET /applications/{client_id}/tokens/{access_token}
client_id=${x_client_id}
     -u ${client_id}:${client_secret} \
        https://${hostname}/api/v3/applications/${client_id}/tokens/${access_token}

legacy-oauth-create-a-new-authorization.sh
client_id=${x_client_id}
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, client_secret: $client_secret, scopes: [ $scopes ], note: $note, note_url: $note_url, fingerprint: $fingerprint  }'  > ${json_file}
#                '{ client_id: $client_id, client_secret: $client_secret, scopes: [ $scopes ], note: $note, note_url: $note_url, fingerprint: $fingerprint  }'  > ${json_file}
# This set up works but the client_id is not set:

legacy-oauth-delete-an-app-token.sh
# DELETE /applications/{client_id}/token

legacy-oauth-device-flow-step3.sh
                --arg client_id "${x_client_id}" \
                '{ client_id: $client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}

legacy-oauth-device-flow-steps1-and-2.sh
                --arg client_id "${x_client_id}" \
                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}

legacy-oauth-get-or-create-an-authorization-for-a-specific-app-and-fingerprint.sh
# PUT /authorizations/clients/{client_id}/{fingerprint}
client_id=${x_client_id}
        https://${hostname}/api/v3/authorizations/clients/${client_id}/${fingerprint} --data @${json_file}

legacy-oauth-get-or-create-an-authorization-for-a-specific-app.sh
# PUT /authorizations/clients/{client_id}
client_id=${x_client_id}
        https://${hostname}/api/v3/authorizations/clients/${client_id} --data @${json_file}

legacy-oauth-list-your-authorizations.sh
client_id=${x_client_id}
        "${GITHUB_API_BASE_URL}/authorizations?client_id=${client_id}":

legacy-oauth-list-your-grants.sh
# If the script is passed an argument $1 use that as the client_id
    client_id=${x_client_id}
    client_id=$1
        "${GITHUB_API_BASE_URL}/applications/grants?client_id=${client_id}"

legacy-oauth-steps1-and-2.sh
# GitHub Apps already have use of the client_id variable
client_id=${x_client_id}
                --arg client_id "${client_id}" \
                '{ client_id: $client_id, scope: $scope  }'  > ${json_file}

legacy-oauth-web-application-flow-step1.sh
client_id=${x_client_id}
open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${client_id}&scope=${url_encoded_scope}"

legacy-oauth-web-application-flow-step2.sh
client_id=${x_client_id}
        "http://${hostname}/login/oauth/access_token?client_id=${client_id}&client_secret=${client_secret}&code=${code}" | jq -r

oauth-device-flow-step3.sh
                '{ client_id: $app_client_id, device_code: $device_code, grant_type: $grant_type }'  > ${json_file}

oauth-device-flow-steps1-and-2.sh
                '{ client_id: $app_client_id, scope: $scope  }'  > ${json_file}

oauth-renew-access-token-and-refresh-token.sh
                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $app_client_id, client_secret: $client_secret }'  > ${json_file}

reset-a-token.sh
# PATCH /applications/{client_id}/token

tiny-github-app-oauth-renew-access-token-and-refresh-token.sh
                '{ refresh_token: $refresh_token, grant_type: $grant_type, client_id: $app_client_id, client_secret: $client_secret }'  > ${json_file}

tiny-github-app-oauth-web-application-flow-step1.sh
open -n -a "Google Chrome" --args --profile-directory="${chrome_profile}"  "http://${hostname}/login/oauth/authorize?client_id=${app_client_id}"

tiny-github-app-oauth-web-application-flow-step2.sh
        "http://${hostname}/login/oauth/access_token?client_id=${app_client_id}&client_secret=${app_client_secret}&code=${code}" | jq -r
```

</details>

While there are still many files that matches with `client_id`, they are fine to leave as is because `client_id` matches:

- A URL path in the comment (e.g. `# POST /applications/{client_id}/token`)
- A local shell variable definition (e.g. `client_id=${x_client_id}`)
- A JSON literal (e.g. `'{ client_id: $app_client_id, scope: $scope  }'  > ${json_file}`)
- A query parameter in the URL (e.g. `"http://${hostname}/login/oauth/access_token?client_id=${app_client_id}&client_secret=${app_client_secret}&code=${code}" | jq -r`)