### PR TITLE
Add OIDC REST API scripts for Actions subject claims and custom properties

### DIFF
--- a/create-an-oidc-custom-property-inclusion-for-an-enterprise.sh
+++ b/create-an-oidc-custom-property-inclusion-for-an-enterprise.sh
@@ -1,0 +1,23 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#create-an-oidc-custom-property-inclusion-for-an-enterprise
+# POST /enterprises/{enterprise}/actions/oidc/customization/properties/repo
+
+# You must authenticate using an access token with the admin:enterprise scope to use this endpoint.
+
+custom_property_name=${1:?You must pass a custom_property_name as the first argument}
+
+json_file=tmp/create-an-oidc-custom-property-inclusion-for-an-enterprise.json
+jq -n \
+       --arg custom_property_name "${custom_property_name}" \
+           '{
+             custom_property_name: $custom_property_name
+           }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/properties/repo" -d @${json_file}

--- a/create-an-oidc-custom-property-inclusion-for-an-organization.sh
+++ b/create-an-oidc-custom-property-inclusion-for-an-organization.sh
@@ -1,0 +1,30 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#create-an-oidc-custom-property-inclusion-for-an-organization
+# POST /orgs/{org}/actions/oidc/customization/properties/repo
+
+# You must authenticate using an access token with the admin:org scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    org=$org
+  else
+    org=$1
+fi
+
+custom_property_name=${2:?You must pass a custom_property_name as the second argument}
+
+json_file=tmp/create-an-oidc-custom-property-inclusion-for-an-organization.json
+jq -n \
+       --arg custom_property_name "${custom_property_name}" \
+           '{
+             custom_property_name: $custom_property_name
+           }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/actions/oidc/customization/properties/repo" -d @${json_file}

--- a/delete-an-oidc-custom-property-inclusion-for-an-enterprise.sh
+++ b/delete-an-oidc-custom-property-inclusion-for-an-enterprise.sh
@@ -1,0 +1,16 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#delete-an-oidc-custom-property-inclusion-for-an-enterprise
+# DELETE /enterprises/{enterprise}/actions/oidc/customization/properties/repo/{custom_property_name}
+
+# You must authenticate using an access token with the admin:enterprise scope to use this endpoint.
+
+custom_property_name=${1:?You must pass a custom_property_name as the first argument}
+
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/properties/repo/${custom_property_name}"

--- a/delete-an-oidc-custom-property-inclusion-for-an-organization.sh
+++ b/delete-an-oidc-custom-property-inclusion-for-an-organization.sh
@@ -1,0 +1,23 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#delete-an-oidc-custom-property-inclusion-for-an-organization
+# DELETE /orgs/{org}/actions/oidc/customization/properties/repo/{custom_property_name}
+
+# You must authenticate using an access token with the admin:org scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    org=$org
+  else
+    org=$1
+fi
+
+custom_property_name=${2:?You must pass a custom_property_name as the second argument}
+
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/actions/oidc/customization/properties/repo/${custom_property_name}"

--- a/get-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh
+++ b/get-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh
@@ -1,0 +1,20 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository
+# GET /repos/{owner}/{repo}/actions/oidc/customization/sub
+
+# You must authenticate using an access token with the repo scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    repo=$repo
+  else
+    repo=$1
+fi
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${org}/${repo}/actions/oidc/customization/sub"

--- a/get-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh
+++ b/get-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh
@@ -1,0 +1,20 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization
+# GET /orgs/{org}/actions/oidc/customization/sub
+
+# You must authenticate using an access token with the read:org scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    org=$org
+  else
+    org=$1
+fi
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/actions/oidc/customization/sub"

--- a/list-oidc-custom-property-inclusions-for-an-enterprise.sh
+++ b/list-oidc-custom-property-inclusions-for-an-enterprise.sh
@@ -1,0 +1,13 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#list-oidc-custom-property-inclusions-for-an-enterprise
+# GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo
+
+# You must authenticate using an access token with the admin:enterprise scope to use this endpoint.
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/actions/oidc/customization/properties/repo"

--- a/list-oidc-custom-property-inclusions-for-an-organization.sh
+++ b/list-oidc-custom-property-inclusions-for-an-organization.sh
@@ -1,0 +1,20 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#list-oidc-custom-property-inclusions-for-an-organization
+# GET /orgs/{org}/actions/oidc/customization/properties/repo
+
+# You must authenticate using an access token with the read:org scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    org=$org
+  else
+    org=$1
+fi
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/actions/oidc/customization/properties/repo"

--- a/set-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh
+++ b/set-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh
@@ -1,0 +1,47 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository
+# PUT /repos/{owner}/{repo}/actions/oidc/customization/sub
+
+# You must authenticate using an access token with the repo scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    repo=$repo
+  else
+    repo=$1
+fi
+
+# Pass use_default as $2 (true or false), and claim keys as $3+
+# Example: ./script.sh my-repo false repo context job_workflow_ref
+# Example: ./script.sh my-repo true
+use_default=${2:-false}
+
+shift 2 2>/dev/null
+
+if [ "$use_default" = "true" ]; then
+  include_claim_keys='[]'
+else
+  if [ $# -eq 0 ]; then
+    include_claim_keys='["repo","context"]'
+  else
+    include_claim_keys=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+  fi
+fi
+
+json_file=tmp/set-the-customization-template-for-an-oidc-subject-claim-for-a-repository.json
+jq -n \
+       --argjson use_default ${use_default} \
+       --argjson include_claim_keys "${include_claim_keys}" \
+           '{
+             use_default: $use_default,
+             include_claim_keys: $include_claim_keys
+           }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X PUT \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${org}/${repo}/actions/oidc/customization/sub" -d @${json_file}

--- a/set-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh
+++ b/set-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh
@@ -1,0 +1,38 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization
+# PUT /orgs/{org}/actions/oidc/customization/sub
+
+# You must authenticate using an access token with the write:org scope to use this endpoint.
+
+if [ -z "$1" ]
+  then
+    org=$org
+  else
+    org=$1
+fi
+
+# Pass claim keys as arguments starting from $2, e.g.: ./script.sh my-org repo context job_workflow_ref
+# Defaults to "repo" and "context" if no claim keys are provided.
+shift 2>/dev/null
+
+if [ $# -eq 0 ]; then
+  include_claim_keys='["repo","context"]'
+else
+  include_claim_keys=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+fi
+
+json_file=tmp/set-the-customization-template-for-an-oidc-subject-claim-for-an-organization.json
+jq -n \
+       --argjson include_claim_keys "${include_claim_keys}" \
+           '{
+             include_claim_keys: $include_claim_keys
+           }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X PUT \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/actions/oidc/customization/sub" -d @${json_file}


### PR DESCRIPTION
Add 10 new scripts covering all GitHub Actions OIDC REST API endpoints:

Enterprise custom property inclusions:
- list-oidc-custom-property-inclusions-for-an-enterprise.sh
- create-an-oidc-custom-property-inclusion-for-an-enterprise.sh
- delete-an-oidc-custom-property-inclusion-for-an-enterprise.sh

Organization custom property inclusions:
- list-oidc-custom-property-inclusions-for-an-organization.sh
- create-an-oidc-custom-property-inclusion-for-an-organization.sh
- delete-an-oidc-custom-property-inclusion-for-an-organization.sh

Organization subject claim templates:
- get-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh
- set-the-customization-template-for-an-oidc-subject-claim-for-an-organization.sh

Repository subject claim templates:
- get-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh
- set-the-customization-template-for-an-oidc-subject-claim-for-a-repository.sh

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
