### PR TITLE
Add missing cost center API endpoint scripts

### DIFF
--- a/add-resources-organization-to-a-cost-center.sh
+++ b/add-resources-organization-to-a-cost-center.sh
@@ -1,0 +1,23 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#add-resources-to-a-cost-center
+# POST /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}/resource
+
+json_file=tmp/add-resources-organization-to-a-cost-center.json
+
+
+
+jq -n \
+           --arg name "${org}" \
+           '{
+            organizations : [ $name ]
+           }' > ${json_file}
+
+
+cat $json_file |  jq -r
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}/resource"  --data @${json_file}

--- a/delete-a-cost-center.sh
+++ b/delete-a-cost-center.sh
@@ -1,0 +1,21 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#delete-a-cost-center
+# DELETE /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}
+
+
+# If the script is passed an argument $1 use that as the cost_center_id
+if [ -z "$1" ]
+  then
+    cost_center_id=$(./get-all-cost-centers-for-an-enterprise.sh | jq -r '.costCenters[-1].id')
+  else
+    cost_center_id=$1
+fi
+
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}"

--- a/get-a-cost-center-by-id.sh
+++ b/get-a-cost-center-by-id.sh
@@ -1,0 +1,20 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#get-a-cost-center-by-id
+# GET /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}
+
+
+# If the script is passed an argument $1 use that as the cost_center_id
+if [ -z "$1" ]
+  then
+    cost_center_id=$(./get-all-cost-centers-for-an-enterprise.sh | jq -r '.costCenters[-1].id')
+  else
+    cost_center_id=$1
+fi
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}" 

--- a/remove-resources-organization-from-a-cost-center.sh
+++ b/remove-resources-organization-from-a-cost-center.sh
@@ -1,0 +1,25 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#remove-resources-from-a-cost-center
+# DELETE /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}/resource
+
+
+cost_center_id=$(./get-all-cost-centers-for-an-enterprise.sh | jq -r '.costCenters[-1].id')
+
+json_file=tmp/remove-resources-organization-from-a-cost-center.json
+
+jq -n \
+           --arg name "${org}" \
+           '{
+            organizations : [ $name ]
+           }' > ${json_file}
+
+
+cat $json_file | jq -r
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}/resource"  --data @${json_file}

--- a/remove-resources-repository-from-a-cost-center.sh
+++ b/remove-resources-repository-from-a-cost-center.sh
@@ -1,0 +1,25 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#remove-resources-from-a-cost-center
+# DELETE /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}/resource
+
+
+cost_center_id=$(./get-all-cost-centers-for-an-enterprise.sh | jq -r '.costCenters[-1].id')
+
+json_file=tmp/remove-resources-repository-from-a-cost-center.json
+
+jq -n \
+           --arg name "${owner}/${repo}" \
+           '{
+            repositories : [ $name ]
+           }' > ${json_file}
+
+
+cat $json_file | jq -r
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}/resource"  --data @${json_file}

--- a/update-a-cost-center-name.sh
+++ b/update-a-cost-center-name.sh
@@ -1,0 +1,29 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/cost-centers?apiVersion=2026-03-10#update-a-cost-center-name
+# PATCH /enterprises/{enterprise}/settings/billing/cost-centers/{cost_center_id}
+
+
+# If the script is passed an argument $1 use that as the cost_center_id
+if [ -z "$1" ]
+  then
+    cost_center_id=$(./get-all-cost-centers-for-an-enterprise.sh | jq -r '.costCenters[-1].id')
+  else
+    cost_center_id=$1
+fi
+
+json_file=tmp/update-a-cost-center-name.json
+
+jq -n \
+           --arg name "${cost_center_name}-updated" \
+           '{
+             name : $name,
+           }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X PATCH \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/cost-centers/${cost_center_id}"  --data @${json_file}


### PR DESCRIPTION
Add coverage for 6 endpoints from the billing/cost-centers API:
- get-a-cost-center-by-id.sh (GET by ID)
- update-a-cost-center-name.sh (PATCH)
- delete-a-cost-center.sh (DELETE)
- add-resources-organization-to-a-cost-center.sh (POST org resource)
- remove-resources-repository-from-a-cost-center.sh (DELETE repo resource)
- remove-resources-organization-from-a-cost-center.sh (DELETE org resource)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
