### PR TITLE
fix: guardrail hooks fail-open instead of fail-closed

### DIFF
--- a/copilot-plugin/hooks/_common.sh
+++ b/copilot-plugin/hooks/_common.sh
@@ -4,10 +4,20 @@
 #
 # Exports: TOOL_NAME, COMMAND
 # Exits 0 (allow) immediately if the tool is not bash or if there is no command.
+#
+# IMPORTANT: Do NOT use `set -e` here. These hooks must fail-open — if anything
+# goes wrong (bad input, missing jq, unexpected payload shape), we exit 0 (allow)
+# rather than erroring out and blocking all tool calls.
 
-set -e
+# Trap: any unexpected error → allow (fail-open, not fail-closed)
+trap 'exit 0' ERR
 
 _INPUT=$(cat 2>/dev/null || true)
+
+# If input is empty or not valid JSON, allow
+if [ -z "$_INPUT" ] || ! echo "$_INPUT" | jq empty 2>/dev/null; then
+  exit 0
+fi
 
 # Defensive: handle missing or malformed JSON gracefully
 TOOL_NAME=$(echo "$_INPUT" | jq -r '.toolName // empty' 2>/dev/null || true)


### PR DESCRIPTION
## Problem

The guardrail hooks in `copilot-plugin/hooks/_common.sh` use `set -e`, which causes the script to exit with a non-zero code if anything unexpected happens before reaching the `toolName != bash → exit 0` check.

When the Copilot CLI invokes these hooks for **non-bash tools** (e.g. Zendesk MCP, GitHub MCP, or any other MCP tool call), the hook errors out rather than returning a clean exit. The CLI interprets a hook error as a denial, which **blocks all tool calls** — including reads, shell commands, and MCP calls.

## Fix

1. Remove `set -e`
2. Add `trap 'exit 0' ERR` — fail-open on unexpected errors
3. Add early validation: if input is empty or not valid JSON, `exit 0` immediately

These hooks only guard against destructive **bash** operations — they should never interfere with non-bash tools.

## Testing

```bash
# Non-bash tool → allowed
echo '{"toolName":"get_ticket_comments","toolArgs":{"ticket_id":"123"}}' | bash hooks/guard-destructive-ops.sh
# exit 0 ✅

# Empty input → allowed
echo '' | bash hooks/guard-destructive-ops.sh
# exit 0 ✅

# Safe bash → allowed
echo '{"toolName":"bash","toolArgs":{"command":"echo hello"},"cwd":"/tmp"}' | bash hooks/guard-destructive-ops.sh
# exit 0 ✅

# Destructive bash → denied (correctly)
echo '{"toolName":"bash","toolArgs":{"command":"./delete-a-repo.sh"},"cwd":"/tmp"}' | bash hooks/guard-destructive-ops.sh
# outputs deny JSON ✅
```

Fixes #579