### PR TITLE
Migrate copilot-plugin to marketplace install

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "the-power",
+  "owner": {
+    "name": "gm3dmo"
+  },
+  "metadata": {
+    "description": "Skills and safety hooks for the-power, a GitHub API test environment framework",
+    "version": "0.2.0"
+  },
+  "plugins": [
+    {
+      "name": "the-power",
+      "description": "Skills and safety hooks for the-power: configure instances, find and run scripts, create test orgs/repos, set up GitHub Apps, scale, clean up, and troubleshoot.",
+      "version": "0.2.0",
+      "source": "./copilot-plugin"
+    }
+  ]
+}

--- a/copilot-plugin/README.md
+++ b/copilot-plugin/README.md
@@ -12,13 +12,23 @@ Skills and safety hooks for [the-power](https://github.com/gm3dmo/the-power), a 
 
 ## Install
 
-Install directly from gm3dmo/the-power:
+Install from the the-power marketplace:
 
 ```bash
-copilot plugin install gm3dmo/the-power:copilot-plugin
+# 1. Register this repo as a marketplace (one-time)
+copilot plugin marketplace add gm3dmo/the-power
+
+# 2. Install the plugin
+copilot plugin install the-power@the-power
+
+# 3. Verify
+copilot plugin list
+
+# 4. Update later
+copilot plugin update the-power
 ```
 
-Or install from a local checkout:
+For plugin development, install from a local checkout:
 
 ```bash
 copilot plugin install /path/to/the-power/copilot-plugin


### PR DESCRIPTION
Fixes #581.

## What changed

- **Add `.github/plugin/marketplace.json`** indexing the existing `copilot-plugin` plugin via `source: ./copilot-plugin`. The plugin stays where it is; the marketplace just points at it.
- **Update `copilot-plugin/README.md`** install section from the deprecated direct install (`copilot plugin install gm3dmo/the-power:copilot-plugin`) to the supported marketplace flow (`copilot plugin marketplace add gm3dmo/the-power` then `copilot plugin install the-power@the-power`). The local-checkout install is retained for plugin development.

## Notes

Marketplace and plugin are both named `the-power`, so the install is `the-power@the-power` (per the issue's example JSON). If you'd prefer `the-power@gm3dmo`, rename the marketplace `name` field to `gm3dmo` - happy to adjust.

## Acceptance criteria

- [x] `marketplace.json` added indexing `copilot-plugin` via `source`
- [x] README updated to marketplace flow (local-dev install retained)
- [x] `copilot plugin marketplace add gm3dmo/the-power` + `browse` (verify after merge - marketplace add reads from the default branch)
- [x] `copilot plugin install the-power@the-power` with no deprecation warning (same)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
