### PR TITLE
Fix preToolUse hook cwd to use ${PLUGIN_ROOT}

### DIFF
--- a/copilot-plugin/hooks.json
+++ b/copilot-plugin/hooks.json
@@ -5,19 +5,19 @@
       {
         "type": "command",
         "bash": "./hooks/guard-destructive-ops.sh",
-        "cwd": ".",
+        "cwd": "${PLUGIN_ROOT}",
         "timeoutSec": 10
       },
       {
         "type": "command",
         "bash": "./hooks/guard-scaling-ops.sh",
-        "cwd": ".",
+        "cwd": "${PLUGIN_ROOT}",
         "timeoutSec": 10
       },
       {
         "type": "command",
         "bash": "./hooks/guard-token-scope.sh",
-        "cwd": ".",
+        "cwd": "${PLUGIN_ROOT}",
         "timeoutSec": 10
       }
     ]


### PR DESCRIPTION
Fixes #583.

## What

The three `preToolUse` guardrail hooks in `copilot-plugin/hooks.json` set `"cwd": "."`, which Copilot CLI resolves against the **project cwd** rather than the plugin root. Once the plugin is installed outside the repo checkout (e.g. under `$COPILOT_HOME/cache/marketplaces/...`), the relative script paths (`./hooks/guard-*.sh`) are not found, the hook errors, and - since CLI 1.0.57 fail-closed - the tool call is denied with `Denied by preToolUse hook from "the-power" (hook errored)`.

## Fix

Anchor each hook to `"cwd": "${PLUGIN_ROOT}"` so the scripts resolve regardless of the project cwd. `PLUGIN_ROOT` has been injected since CLI 1.0.26, and `cwd` expansion of plugin vars landed in 1.0.60, so this works on 1.0.60+.

Verified workaround per [github/copilot-cli#2540 (comment)](https://github.com/github/copilot-cli/issues/2540#issuecomment-4650326917).

## Notes

- Related: #581 (marketplace install) - the install path that exposes this mismatch.
- Related: #579 (a different hook failure mode, `set -e` in `_common.sh`).