### PR TITLE
Make token-scope guard warn instead of deny on classic PAT

### DIFF
--- a/copilot-plugin/hooks/_common.sh
+++ b/copilot-plugin/hooks/_common.sh
@@ -41,6 +41,12 @@ deny() {
   exit 0
 }
 
+# Helper: print a red warning to stderr but allow the command to proceed
+warn() {
+  printf '\033[31m⚠ %s\033[0m\n' "$1" >&2
+  exit 0
+}
+
 # Helper: find .gh-api-examples.conf by walking up from the command's
 # working directory (cwd from payload), falling back to PWD.
 find_config() {

--- a/copilot-plugin/hooks/guard-token-scope.sh
+++ b/copilot-plugin/hooks/guard-token-scope.sh
@@ -23,5 +23,5 @@ fi
 # Check if using a classic PAT
 TOKEN=$(grep -E "^GITHUB_TOKEN=" "$CONFIG" 2>/dev/null | head -1 | cut -d'=' -f2 | tr -d '"' | tr -d "'" | xargs)
 if echo "$TOKEN" | grep -q "^ghp_"; then
-  deny "You appear to be using a classic PAT (ghp_) on github.com. Consider using a fine-grained personal access token for better security. Confirm with the user before proceeding."
+  warn "You appear to be using a classic PAT (ghp_) on github.com. Consider using a fine-grained personal access token for better security."
 fi


### PR DESCRIPTION
## What

Changes the `guard-token-scope` preToolUse hook so that using a classic PAT (`ghp_`) against github.com produces a **non-blocking red warning** instead of denying the command.

## Why

Denying blocked scripts outright (and prompted for confirmation). A classic PAT is a security suggestion, not a hard error, so a warning is more appropriate — the command still proceeds.

## Changes

- `copilot-plugin/hooks/_common.sh`: add a `warn()` helper that prints a red `⚠ …` message to stderr and exits 0 (allow).
- `copilot-plugin/hooks/guard-token-scope.sh`: use `warn` instead of `deny`; message trimmed to drop the confirmation prompt.

## Verification

With a classic `ghp_` PAT configured on `api.github.com`, running a script now emits a red warning and exits 0 (command allowed, no prompt).