### PR TITLE
Add dual-purpose populate/verify/cleanup helpers to scale-environment

### DIFF
--- a/cleanup-populated-instance.sh
+++ b/cleanup-populated-instance.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# cleanup-populated-instance.sh — delete resources created by
+# populate-instance.sh, matched by --prefix. Prefix-scoped so it will not touch
+# resources you did not create on a shared instance (unlike "delete the whole org").
+#
+# Dual-purpose: connection settings come from .gh-api-examples.conf, so
+# ${GITHUB_API_BASE_URL} is already correct for GHES (/api/v3) or dotcom. On cloud,
+# user suspend is a GHES-only no-op and org delete may be restricted.
+#
+# DESTRUCTIVE — requires an explicit typed confirmation (or --yes).
+#
+# Usage:
+#   ./cleanup-populated-instance.sh [--prefix STR] [--hostname HOST] [--token PAT]
+#                                   [--yes] [--suspend-users]
+set -uo pipefail
+
+if [ -f ./.gh-api-examples.conf ]; then
+  # shellcheck disable=SC1091
+  .  ./.gh-api-examples.conf
+fi
+
+PREFIX="sim"; HOSTNAME_IN=""; TOKEN="${GITHUB_TOKEN:-}"; ASSUME_YES=0; SUSPEND=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix) PREFIX="$2"; shift 2;;
+    --hostname) HOSTNAME_IN="$2"; shift 2;;
+    --token) TOKEN="$2"; shift 2;;
+    --yes) ASSUME_YES=1; shift;;
+    --suspend-users) SUSPEND=1; shift;;
+    -h|--help) echo "Usage: $0 [--prefix STR] [--hostname HOST] [--token PAT] [--yes] [--suspend-users]"; exit 0;;
+    *) echo "Unknown arg: $1" >&2; exit 1;;
+  esac
+done
+[ -z "$TOKEN" ] && { echo "ERROR: no token. Set GITHUB_TOKEN in .gh-api-examples.conf or pass --token." >&2; exit 1; }
+
+if [ -n "$HOSTNAME_IN" ]; then
+  HOST="${HOSTNAME_IN#http://}"; HOST="${HOST#https://}"; HOST="${HOST%%/}"
+  case "$HOST" in
+    api.github.com) API="https://api.github.com";;
+    *)              API="https://${HOST}/api/v3";;
+  esac
+elif [ -n "${GITHUB_API_BASE_URL:-}" ]; then
+  API="${GITHUB_API_BASE_URL}"
+  HOST="${API#http://}"; HOST="${HOST#https://}"; HOST="${HOST%%/*}"
+else
+  echo "ERROR: no hostname. Set it in .gh-api-examples.conf or pass --hostname." >&2
+  exit 1
+fi
+CURLF="${curl_custom_flags:---no-progress-meter}"
+api()  { local m="$1" p="$2"; curl $CURLF -sS -X "$m" -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "$API$p"; }
+code() { local m="$1" p="$2"; curl $CURLF -sS -o /dev/null -w '%{http_code}' -X "$m" -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "$API$p"; }
+
+REPOS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && REPOS+=("$line")
+done < <(api GET "/search/repositories?q=${PREFIX}-repo+in:name&per_page=100" | grep -o '"full_name": *"[^"]*"' | sed 's/.*": *"\([^"]*\)"/\1/')
+
+echo "Instance: ${API}"
+echo "Matched ${#REPOS[@]} repos with prefix '${PREFIX}-repo'."
+[ ${#REPOS[@]} -gt 0 ] && printf '  %s\n' "${REPOS[@]}" | head -20
+
+if [ $ASSUME_YES -ne 1 ]; then
+  echo
+  read -r -p "Type the hostname '${HOST}' to confirm deletion: " ans
+  [ "$ans" = "$HOST" ] || { echo "Aborted."; exit 1; }
+fi
+
+for slug in ${REPOS[@]+"${REPOS[@]}"}; do
+  st=$(code DELETE "/repos/$slug")
+  echo "  deleted repo $slug (HTTP $st)"
+done
+
+# delete prefixed orgs (best-effort; GHES admin API, restricted on cloud)
+for i in $(seq 1 20); do
+  org="${PREFIX}-org-$(printf '%02d' "$i")"
+  ec=$(code GET "/orgs/$org"); [ "$ec" != "200" ] && continue
+  st=$(code DELETE "/orgs/$org")
+  echo "  deleted org $org (HTTP $st)"
+done
+
+if [ $SUSPEND -eq 1 ]; then
+  for i in $(seq 1 100); do
+    u="${PREFIX}-user-$(printf '%03d' "$i")"
+    ec=$(code GET "/users/$u"); [ "$ec" != "200" ] && continue
+    st=$(code PUT "/users/$u/suspended")
+    echo "  suspended user $u (HTTP $st)"
+  done
+fi
+
+echo "Cleanup complete."

--- a/copilot-plugin/hooks/guard-destructive-ops.sh
+++ b/copilot-plugin/hooks/guard-destructive-ops.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 DESTRUCTIVE_PATTERNS=(
   "delete-"
+  "cleanup-populated-instance"
   "suspend-a-user"
   "cancel-an-organization-invitation"
   "remove-"

--- a/copilot-plugin/hooks/guard-scaling-ops.sh
+++ b/copilot-plugin/hooks/guard-scaling-ops.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_common.sh"
 
 # Only check bulk creation scripts
-if ! echo "$COMMAND" | grep -qE "(create-many-|python-create-many-)"; then
+if ! echo "$COMMAND" | grep -qE "(create-many-|python-create-many-|populate-instance)"; then
   exit 0
 fi
 

--- a/copilot-plugin/skills/scale-environment/SKILL.md
+++ b/copilot-plugin/skills/scale-environment/SKILL.md
@@ -4,6 +4,8 @@ description: >
   Scale up a test environment by bulk-creating repos, users, orgs, teams,
   issues, branches, PRs, and commits using the-power's create-many scripts.
   Three performance tiers: shell, Python connection reuse, and Python pooling.
+  Also seeds realistic activity and verifies or cleans it up by prefix, on both
+  GHES and github.com.
 keywords:
   - scale
   - bulk
@@ -16,6 +18,11 @@ keywords:
   - teams
   - load
   - populate
+  - seed
+  - verify
+  - cleanup
+  - traffic
+  - audit-log
 ---
 
 # Scale Environment
@@ -164,6 +171,78 @@ pip install urllib3
 python3 python-create-many-repos-connection-reuse-pool.py \
   --repos 1000 --prefix load --org acme
 ```
+
+## Seed realistic activity, then verify and clean up
+
+`create-many-*` and the goodies inflate script are the right tools for raw
+volume. When you instead want an instance that *looks used* — varied commit
+authors, a merged pull request, issues that are labelled, assigned, commented on
+and half of them closed, stars, topics, and some read traffic — use the
+`populate-instance.sh` helper. It is tuned for audit-log and monitoring traffic
+rather than sheer counts, so it pairs well with the bulk scripts above.
+
+These helpers are dual-purpose. They read connection settings from
+`.gh-api-examples.conf`, so `GITHUB_API_BASE_URL` is already correct for GHES
+(`/api/v3`) or github.com. Run `configure.py` first (see the `configure` skill),
+which prompts for the hostname and token. If there is no config yet, ask the
+user for the **hostname** and a **personal access token**, then:
+
+```bash
+python3 configure.py --hostname <HOST> --token <PAT>
+```
+
+### Seed
+
+```bash
+# GHES: creates orgs + users + teams + inflated repos
+./populate-instance.sh --scale light --prefix demo
+
+# github.com / GHEC: user and org admin APIs do not exist, so pass --no-users
+# and seed into an existing org. Cloud targets need --yes to acknowledge that
+# real resources are being created.
+./populate-instance.sh --scale light --prefix demo --no-users --org my-existing-org --yes
+```
+
+Preview first with `--dry-run` (offline, no changes). Scale presets are
+`light` (2 orgs / 5 users / 3 repos-per-org), `medium`, and `heavy`; override any
+count with `--orgs`, `--users`, or `--repos-per-org`. For lab instances with a
+self-signed certificate, set `curl_custom_flags="--insecure"` in the config.
+
+### Verify
+
+There is no built-in way to confirm what a seed produced, so tally it by prefix:
+
+```bash
+./verify-populated-instance.sh --prefix demo
+```
+
+This prints per-repo branch, PR, issue, and commit counts for everything matching
+the prefix.
+
+### Clean up
+
+`cleanup-populated-instance.sh` removes only the prefixed repos and orgs (and,
+with `--suspend-users`, the prefixed users on GHES), so it is safe on a shared
+instance where deleting the whole org is not an option:
+
+```bash
+./cleanup-populated-instance.sh --prefix demo            # prompts to confirm the hostname
+./cleanup-populated-instance.sh --prefix demo --yes      # non-interactive
+```
+
+### GHES vs github.com
+
+| Behaviour | GHES | github.com / GHEC |
+|-----------|------|-------------------|
+| API base URL | `https://HOST/api/v3` | `https://api.github.com` |
+| Create users | `/admin/users` | not available — use `--no-users` |
+| Create orgs | `/admin/organizations` | not available — seed into an existing `--org` |
+| Cloud confirm-gate | not triggered | requires `--yes` |
+
+The helpers never hard-refuse a cloud host, because the-power supports both
+cloud and self-hosted. A production-looking host triggers a warning and requires
+`--yes` instead. Always confirm the target instance and counts with the user
+before seeding.
 
 ## Error handling
 

--- a/copilot-plugin/tests/test-guardrails.sh
+++ b/copilot-plugin/tests/test-guardrails.sh
@@ -119,6 +119,9 @@ run_test "dismiss-a-review denied" "$HOOK" \
 run_test "revoke-a-list-of-credentials denied" "$HOOK" \
   "$(make_input bash './revoke-a-list-of-credentials.sh')" "deny" "destructive"
 
+run_test "cleanup-populated-instance denied" "$HOOK" \
+  "$(make_input bash './cleanup-populated-instance.sh --prefix demo')" "deny" "destructive"
+
 run_test "delete in pipe allowed (not a script name)" "$HOOK" \
   "$(make_input bash 'echo hello | grep delete')" "allow"
 
@@ -158,6 +161,12 @@ run_test "inline number_of_repos=200 denied" "$HOOK" \
 
 run_test "inline number_of_repos=10 allowed" "$HOOK" \
   "$(make_input bash 'number_of_repos=10 ./create-many-repos.sh')" "allow"
+
+run_test "populate-instance --orgs 500 denied" "$HOOK" \
+  "$(make_input bash './populate-instance.sh --orgs 500')" "deny" "high count"
+
+run_test "populate-instance --users 5 allowed" "$HOOK" \
+  "$(make_input bash './populate-instance.sh --users 5')" "allow"
 
 run_test "inline number_of_issues=500 denied" "$HOOK" \
   "$(make_input bash 'number_of_issues=500 ./create-many-issues.sh')" "deny" "high count"

--- a/populate-instance.sh
+++ b/populate-instance.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# populate-instance.sh — seed a test instance with realistic, log-generating
+# activity: orgs, users, teams, repos, then inflate each repo with multi-author
+# commits, feature branches, a merged pull request, issues (labelled, assigned,
+# commented, ~half closed), a star, topics, and a clone/fetch read cycle.
+#
+# Dual-purpose (GitHub Enterprise Server AND GitHub Cloud / dotcom):
+#   - Connection settings come from .gh-api-examples.conf (run configure.py first),
+#     so ${GITHUB_API_BASE_URL} is already correct for GHES (/api/v3) or dotcom.
+#   - User + org creation use GHES-only site-admin APIs; on cloud they are skipped
+#     automatically and repos are seeded into the ${org} from your config instead.
+#
+# This complements create-many-* (single-type bulk) and the goodies inflate
+# script (write-only, single-author): this one is tuned for realistic *activity*
+# and audit-log / monitoring traffic.
+#
+# Usage:
+#   ./populate-instance.sh [options]
+#
+# Config (from .gh-api-examples.conf, overridable):
+#   --hostname HOST     API hostname (default: from conf). Full https:// URL is fine.
+#   --token PAT         personal access token (default: GITHUB_TOKEN from conf)
+#   --org NAME          target org on cloud / fallback org name (default: org from conf)
+#
+# Scale:
+#   --scale TIER        light | medium | heavy  (preset counts; default: light)
+#   --orgs N            orgs to create (GHES admin API)
+#   --users N           users to create (GHES admin API)
+#   --repos-per-org N   repos created inside each org
+#   --prefix STR        name prefix for everything created (default: sim)
+#   --owner-users a,b   existing logins to use as collaborators/assignees/mentions
+#   --no-users          skip user creation (cloud, or restricted instances)
+#
+# Safety / behaviour:
+#   --dry-run           print what would be created, make no changes
+#   --yes               acknowledge a GitHub Cloud target (required for dotcom hosts)
+#   -h | --help         this help
+#
+# Everything created shares the --prefix and repos are tagged with the topic
+# "sim-generated", so verify-populated-instance.sh and cleanup-populated-instance.sh
+# can find it precisely.
+
+set -uo pipefail
+
+# ---------- load the-power config (idiomatic: every script sources this) ----------
+if [ -f ./.gh-api-examples.conf ]; then
+  # shellcheck disable=SC1091
+  .  ./.gh-api-examples.conf
+fi
+
+# ---------- defaults ----------
+HOSTNAME_IN=""; TOKEN="${GITHUB_TOKEN:-}"; ORG_IN="${org:-}"
+SCALE="light"; PREFIX="sim"
+ORGS=""; USERS=""; RPO=""; OWNER_USERS=""; MAKE_USERS=1
+DRYRUN=0; ASSUME_YES=0
+TOPIC="sim-generated"
+
+usage() { sed -n '2,58p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# ---------- args ----------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --hostname) HOSTNAME_IN="$2"; shift 2;;
+    --token) TOKEN="$2"; shift 2;;
+    --org) ORG_IN="$2"; shift 2;;
+    --scale) SCALE="$2"; shift 2;;
+    --orgs) ORGS="$2"; shift 2;;
+    --users) USERS="$2"; shift 2;;
+    --repos-per-org) RPO="$2"; shift 2;;
+    --prefix) PREFIX="$2"; shift 2;;
+    --owner-users) OWNER_USERS="$2"; shift 2;;
+    --no-users) MAKE_USERS=0; shift;;
+    --dry-run) DRYRUN=1; shift;;
+    --yes) ASSUME_YES=1; shift;;
+    -h|--help) usage 0;;
+    *) echo "Unknown arg: $1" >&2; usage 1;;
+  esac
+done
+
+[ -z "$TOKEN" ] && { echo "ERROR: no token. Set GITHUB_TOKEN in .gh-api-examples.conf (run configure.py) or pass --token." >&2; exit 1; }
+
+# token format sanity (mirrors the-power)
+case "$TOKEN" in
+  ghp_*|github_pat_*|gho_*|ghu_*|ghs_*|ghr_*) : ;;
+  *) echo "ERROR: token does not look like a GitHub token (ghp_/github_pat_/gho_/...)." >&2; exit 1;;
+esac
+
+# ---------- resolve API base URL (dual-purpose: GHES vs dotcom) ----------
+# Prefer the value configure.py already computed; only rebuild it if the caller
+# overrode --hostname, applying the same rule configure.py uses.
+if [ -n "$HOSTNAME_IN" ]; then
+  HOST="${HOSTNAME_IN#http://}"; HOST="${HOST#https://}"; HOST="${HOST%%/}"
+  case "$HOST" in
+    api.github.com) API="https://api.github.com";;
+    *)              API="https://${HOST}/api/v3";;
+  esac
+elif [ -n "${GITHUB_API_BASE_URL:-}" ]; then
+  API="${GITHUB_API_BASE_URL}"
+  HOST="${API#http://}"; HOST="${HOST#https://}"; HOST="${HOST%%/*}"
+else
+  echo "ERROR: no hostname. Set it in .gh-api-examples.conf (run configure.py) or pass --hostname." >&2
+  exit 1
+fi
+
+# ---------- scale presets ----------
+case "$SCALE" in
+  light)  ORGS="${ORGS:-2}"; USERS="${USERS:-5}";  RPO="${RPO:-3}";;
+  medium) ORGS="${ORGS:-5}"; USERS="${USERS:-15}"; RPO="${RPO:-5}";;
+  heavy)  ORGS="${ORGS:-10}";USERS="${USERS:-40}"; RPO="${RPO:-8}";;
+  *) echo "ERROR: --scale must be light|medium|heavy" >&2; exit 1;;
+esac
+
+# honour the-power's curl_custom_flags (e.g. --insecure for self-signed GHES certs)
+CURLF="${curl_custom_flags:---no-progress-meter}"
+TOK_SHOW="${TOKEN:0:8}…"
+
+# ---------- helpers ----------
+api() { # METHOD PATH [json]
+  local m="$1" p="$2" d="${3:-}"
+  if [ -n "$d" ]; then
+    curl $CURLF -sS -X "$m" -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github+json" "$API$p" -d "$d"
+  else
+    curl $CURLF -sS -X "$m" -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github+json" "$API$p"
+  fi
+}
+code() { # METHOD PATH [json] -> http status
+  local m="$1" p="$2" d="${3:-}"
+  if [ -n "$d" ]; then
+    curl $CURLF -sS -o /dev/null -w '%{http_code}' -X "$m" -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github+json" "$API$p" -d "$d"
+  else
+    curl $CURLF -sS -o /dev/null -w '%{http_code}' -X "$m" -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github+json" "$API$p"
+  fi
+}
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+jnum() { grep -o "\"$1\": *[0-9]*" | head -1 | grep -o '[0-9]*'; }
+pick() { local a=("$@"); echo "${a[$((RANDOM % ${#a[@]}))]}"; }
+
+# ---------- preflight ----------
+log "Target:   ${API}"
+log "Token:    ${TOK_SHOW}"
+log "Scale:    ${SCALE}  -> orgs=${ORGS} users=${USERS} repos/org=${RPO} prefix=${PREFIX}"
+[ $DRYRUN -eq 1 ] && log "DRY RUN — no changes will be made"
+
+if [ $DRYRUN -eq 1 ]; then
+  echo "Would create: ${ORGS} orgs, ${USERS} users, $((ORGS*RPO)) repos, plus per-repo inflate (commits/branches/merged PR/issues/star/topics/read)."
+  exit 0
+fi
+
+# confirm-gate for GitHub Cloud (dotcom / data-residency) targets — the-power is
+# dual-purpose, so we DO allow cloud, but require explicit acknowledgement because
+# it acts on real accounts/orgs. Not a hard block.
+case "$HOST" in
+  api.github.com|github.com|*.ghe.com)
+    if [ $ASSUME_YES -ne 1 ] && [ $DRYRUN -ne 1 ]; then
+      echo "" >&2
+      echo "WARNING: '${HOST}' is GitHub Cloud. This will create real repos/issues/PRs" >&2
+      echo "         under the '${ORG_IN:-<org from config>}' organisation." >&2
+      echo "         Re-run with --yes once you have confirmed the target with the user." >&2
+      exit 2
+    fi
+    ;;
+esac
+
+ME=$(api GET "/user" | grep -o '"login": *"[^"]*"' | head -1 | sed 's/.*"login": *"\([^"]*\)".*/\1/')
+if [ -z "$ME" ]; then
+  echo "ERROR: could not authenticate against ${API}. Check hostname/token (and curl_custom_flags=\"--insecure\" for self-signed lab certs)." >&2
+  exit 1
+fi
+log "Authenticated as: ${ME}"
+
+# collaborators/mentions pool: provided list + created users get appended
+POOL=()
+if [ -n "$OWNER_USERS" ]; then IFS=',' read -r -a POOL <<< "$OWNER_USERS"; fi
+
+# ---------- 1. users (GHES site-admin API; skipped on cloud) ----------
+CREATED_USERS=0
+if [ $MAKE_USERS -eq 1 ]; then
+  log "Creating ${USERS} users via /admin/users ..."
+  for i in $(seq 1 "$USERS"); do
+    u="${PREFIX}-user-$(printf '%03d' "$i")"
+    st=$(code POST "/admin/users" "{\"login\":\"$u\",\"email\":\"${u}@example.com\"}")
+    if [ "$st" = "201" ] || [ "$st" = "202" ]; then
+      CREATED_USERS=$((CREATED_USERS+1)); POOL+=("$u")
+    elif [ "$st" = "422" ]; then
+      POOL+=("$u")   # already exists — still usable
+    elif [ "$st" = "403" ] || [ "$st" = "404" ]; then
+      log "  user API unavailable (HTTP $st) — likely GitHub Cloud / no site-admin. Skipping user creation."
+      break
+    fi
+  done
+  log "Users created: ${CREATED_USERS} (pool size: ${#POOL[@]})"
+fi
+[ ${#POOL[@]} -eq 0 ] && POOL=("$ME")
+
+# ---------- per-repo inflate ----------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+GITOPT=""
+case "$CURLF" in *--insecure*|*-k*) GITOPT="-c http.sslVerify=false";; esac
+
+inflate_repo() { # org repo lang
+  local org="$1" repo="$2" lang="$3"
+  local slug="$org/$repo"
+  local url="https://${TOKEN}@${HOST}/${slug}.git" d="$WORK/$repo"
+  rm -rf "$d"; mkdir -p "$d"
+  git $GITOPT -C "$d" init -q -b main
+  cat > "$d/README.md" <<EOF
+# $repo
+
+Part of the $org test org ($lang). Generated for load/log testing.
+EOF
+  printf '*.log\nnode_modules/\n__pycache__/\n' > "$d/.gitignore"
+  echo "MIT" > "$d/LICENSE"
+  case "$lang" in
+    py) mkdir -p "$d/src"; printf 'def add(a,b):\n    return a+b\n' > "$d/src/app.py";;
+    go) printf 'package main\nfunc Add(a,b int)int{return a+b}\nfunc main(){}\n' > "$d/main.go";;
+    js) mkdir -p "$d/src"; printf 'module.exports.add=(a,b)=>a+b;\n' > "$d/src/index.js";;
+  esac
+  git $GITOPT -C "$d" add -A
+  git $GITOPT -C "$d" -c user.name="$ME" -c user.email="${ME}@example.com" commit -qm "Initial commit: $repo"
+  git $GITOPT -C "$d" remote add origin "$url"
+  git $GITOPT -C "$d" push -q origin main 2>/dev/null
+
+  # extra commits on main, varied authors (realistic multi-actor history)
+  local msgs=("docs: expand README" "chore: bump deps" "feat: add endpoint" "fix: handle edge case" "test: add cases")
+  for m in "${msgs[@]}"; do
+    echo "// $m $(date +%s)" >> "$d/CHANGELOG.md"
+    git $GITOPT -C "$d" add -A
+    git $GITOPT -C "$d" -c user.name="$(pick "${POOL[@]}")" -c user.email="dev@example.com" commit -qm "$m"
+  done
+  git $GITOPT -C "$d" push -q origin main 2>/dev/null
+
+  # labels
+  for lb in '{"name":"bug","color":"d73a4a"}' '{"name":"enhancement","color":"a2eeef"}'; do
+    api POST "/repos/$slug/labels" "$lb" >/dev/null
+  done
+
+  # feature branches + PRs (one gets merged)
+  local prnums=() b
+  for b in feature-a bugfix-b feature-c; do
+    git $GITOPT -C "$d" checkout -q -b "$b" main
+    echo "// $b $(date +%s)" >> "$d/src_${b}.txt"
+    git $GITOPT -C "$d" add -A
+    git $GITOPT -C "$d" -c user.name="$(pick "${POOL[@]}")" -c user.email="dev@example.com" commit -qm "feat($b): work"
+    git $GITOPT -C "$d" push -q origin "$b" 2>/dev/null
+    local pr num
+    pr=$(api POST "/repos/$slug/pulls" "{\"title\":\"Add $b\",\"head\":\"$b\",\"base\":\"main\",\"body\":\"Implements $b. cc @$(pick "${POOL[@]}")\"}")
+    num=$(echo "$pr" | jnum number)
+    if [ -n "$num" ]; then
+      prnums+=("$num")
+      api POST "/repos/$slug/issues/$num/comments" '{"body":"LGTM overall."}' >/dev/null
+    fi
+    git $GITOPT -C "$d" checkout -q main
+  done
+  [ -n "${prnums[0]:-}" ] && api PUT "/repos/$slug/pulls/${prnums[0]}/merge" "{\"merge_method\":\"merge\"}" >/dev/null
+
+  # issues (labelled, assigned, commented, ~half closed)
+  local titles=("Crash on empty config" "Add retry logic" "Docs: update examples" "Memory leak under load" "Improve coverage")
+  for t in "${titles[@]}"; do
+    local iss inum
+    iss=$(api POST "/repos/$slug/issues" "{\"title\":\"$t\",\"body\":\"Steps to reproduce... cc @$(pick "${POOL[@]}")\",\"labels\":[\"$(pick bug enhancement)\"],\"assignees\":[\"$(pick "${POOL[@]}")\"]}")
+    inum=$(echo "$iss" | jnum number)
+    if [ -n "$inum" ]; then
+      api POST "/repos/$slug/issues/$inum/comments" '{"body":"Reproduced, investigating."}' >/dev/null
+      [ $((RANDOM % 2)) -eq 0 ] && api PATCH "/repos/$slug/issues/$inum" '{"state":"closed"}' >/dev/null
+    fi
+  done
+
+  # metadata + read traffic (star, topics, clone/fetch)
+  api PUT "/user/starred/$slug" "" >/dev/null
+  api PUT "/repos/$slug/topics" "{\"names\":[\"$TOPIC\",\"$PREFIX\",\"$lang\"]}" >/dev/null
+  local c="$WORK/${repo}-clone"; rm -rf "$c"
+  git $GITOPT clone -q "$url" "$c" 2>/dev/null && git $GITOPT -C "$c" fetch -q --all 2>/dev/null
+  rm -rf "$c" "$d"
+}
+
+# ---------- 2. orgs + teams + repos ----------
+LANGS=(py go js)
+CREATED_ORGS=0; CREATED_REPOS=0
+for o in $(seq 1 "$ORGS"); do
+  org="${PREFIX}-org-$(printf '%02d' "$o")"
+  st=$(code POST "/admin/organizations" "{\"login\":\"$org\",\"admin\":\"$ME\",\"profile_name\":\"$org\"}")
+  if [ "$st" != "201" ] && [ "$st" != "422" ]; then
+    # admin org API unavailable (cloud): seed into the configured org instead
+    if [ -n "$ORG_IN" ]; then
+      org="$ORG_IN"
+      log "org admin API unavailable (HTTP $st) — seeding into existing org '${org}'."
+    else
+      log "org ${org} create failed (HTTP $st) and no --org/config org to fall back to. Skipping."
+      continue
+    fi
+  else
+    [ "$st" = "201" ] && CREATED_ORGS=$((CREATED_ORGS+1))
+    log "org ${org} (HTTP $st)"
+    # a team per created org
+    api POST "/orgs/$org/teams" "{\"name\":\"${PREFIX}-team\",\"privacy\":\"closed\"}" >/dev/null
+    # add a few members to the org
+    for u in "${POOL[@]:0:3}"; do
+      [ "$u" != "$ME" ] && api PUT "/orgs/$org/memberships/$u" '{"role":"member"}' >/dev/null
+    done
+  fi
+
+  # repos in this org, inflated
+  for r in $(seq 1 "$RPO"); do
+    repo="${PREFIX}-repo-$(printf '%02d' "$o")-$(printf '%02d' "$r")"
+    lang="$(pick "${LANGS[@]}")"
+    st=$(code POST "/orgs/$org/repos" "{\"name\":\"$repo\",\"private\":false,\"has_issues\":true,\"auto_init\":false}")
+    if [ "$st" = "201" ]; then
+      CREATED_REPOS=$((CREATED_REPOS+1))
+      log "  repo ${org}/${repo} ($lang) — inflating"
+      inflate_repo "$org" "$repo" "$lang"
+    else
+      log "  repo ${org}/${repo} create failed (HTTP $st)"
+    fi
+  done
+done
+
+log "DONE. orgs=${CREATED_ORGS} users=${CREATED_USERS} repos=${CREATED_REPOS}"
+echo
+echo "Verify with:   ./verify-populated-instance.sh --prefix $PREFIX"
+echo "Clean up with: ./cleanup-populated-instance.sh --prefix $PREFIX"

--- a/verify-populated-instance.sh
+++ b/verify-populated-instance.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# verify-populated-instance.sh — tally the resources created by
+# populate-instance.sh, matched by --prefix. Fills the gap where the-power can
+# confirm a token/org is valid but has no post-seed "did it actually land?" count.
+#
+# Dual-purpose: connection settings come from .gh-api-examples.conf, so
+# ${GITHUB_API_BASE_URL} is already correct for GHES (/api/v3) or dotcom.
+#
+# Usage:
+#   ./verify-populated-instance.sh [--prefix STR] [--hostname HOST] [--token PAT]
+set -uo pipefail
+
+if [ -f ./.gh-api-examples.conf ]; then
+  # shellcheck disable=SC1091
+  .  ./.gh-api-examples.conf
+fi
+
+PREFIX="sim"; HOSTNAME_IN=""; TOKEN="${GITHUB_TOKEN:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix) PREFIX="$2"; shift 2;;
+    --hostname) HOSTNAME_IN="$2"; shift 2;;
+    --token) TOKEN="$2"; shift 2;;
+    -h|--help) echo "Usage: $0 [--prefix STR] [--hostname HOST] [--token PAT]"; exit 0;;
+    *) echo "Unknown arg: $1" >&2; exit 1;;
+  esac
+done
+[ -z "$TOKEN" ] && { echo "ERROR: no token. Set GITHUB_TOKEN in .gh-api-examples.conf or pass --token." >&2; exit 1; }
+
+if [ -n "$HOSTNAME_IN" ]; then
+  HOST="${HOSTNAME_IN#http://}"; HOST="${HOST#https://}"; HOST="${HOST%%/}"
+  case "$HOST" in
+    api.github.com) API="https://api.github.com";;
+    *)              API="https://${HOST}/api/v3";;
+  esac
+elif [ -n "${GITHUB_API_BASE_URL:-}" ]; then
+  API="${GITHUB_API_BASE_URL}"
+else
+  echo "ERROR: no hostname. Set it in .gh-api-examples.conf or pass --hostname." >&2
+  exit 1
+fi
+CURLF="${curl_custom_flags:---no-progress-meter}"
+api() { curl $CURLF -sS -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "$API$1"; }
+
+echo "Instance: ${API}   prefix: ${PREFIX}"
+echo
+
+printf "%-28s %6s %5s %5s %6s\n" REPO BRANCH PR ISSUE COMMIT
+tot_pr=0; tot_iss=0; tot_br=0; n=0
+for slug in $(api "/search/repositories?q=${PREFIX}-repo+in:name&per_page=100" | grep -o '"full_name": *"[^"]*"' | sed 's/.*": *"\([^"]*\)"/\1/'); do
+  br=$(api "/repos/$slug/branches?per_page=100" | grep -o '"name":' | wc -l | tr -d ' ')
+  pr=$(api "/repos/$slug/pulls?state=all&per_page=100" | grep -o '"number":' | wc -l | tr -d ' ')
+  ai=$(api "/repos/$slug/issues?state=all&per_page=100" | grep -o '"number":' | wc -l | tr -d ' ')
+  cm=$(api "/repos/$slug/commits?per_page=100" | grep -o '"sha":' | wc -l | tr -d ' '); cm=$((cm/2))
+  iss=$((ai - pr))
+  printf "%-28s %6s %5s %5s %6s\n" "${slug##*/}" "$br" "$pr" "$iss" "$cm"
+  tot_br=$((tot_br+br)); tot_pr=$((tot_pr+pr)); tot_iss=$((tot_iss+iss)); n=$((n+1))
+done
+echo "-----"
+echo "Repos matched: ${n}   branches=${tot_br}  PRs=${tot_pr}  issues=${tot_iss}"


### PR DESCRIPTION
## What

Adds three repo-root helper scripts and wires them into the `scale-environment` skill, its guardrails, and tests. They seed a test instance with realistic, log-generating activity, then verify and clean it up **by prefix**.

| Script | Purpose |
|--------|---------|
| `populate-instance.sh` | Seed orgs/users/teams and inflated repos with varied commit authors, a merged PR, labelled/assigned/commented issues (about half closed), stars, topics, and a clone/fetch read cycle. Offline `--dry-run`, scale presets, `--prefix` tag. |
| `verify-populated-instance.sh` | Prefix-scoped tally of repos/branches/PRs/issues/commits. |
| `cleanup-populated-instance.sh` | Prefix-scoped delete of repos/orgs, plus optional GHES user suspend. |

## Why

`create-many-*` and the goodies inflate script are great for raw volume, but there was no helper that produces an instance that *looks used* (multi-actor history, merged PRs, closed issues, read traffic) for audit-log and monitoring testing, and no post-seed way to confirm what landed. These complement the existing bulk scripts rather than replacing them.

## Dual-purpose (GHES and github.com)

- Scripts source `.gh-api-examples.conf` and use `GITHUB_API_BASE_URL`, so the base URL is already correct for GHES (`/api/v3`) or dotcom. No hardcoded paths.
- GHES-only admin APIs (user/org creation) degrade gracefully on cloud (`--no-users`, seed into an existing `--org`).
- Cloud targets require an explicit `--yes` confirm-gate rather than a hard refusal, matching the-power's dual-purpose design and the existing warn-don't-block guardrails.
- Token never printed beyond the first 8 characters. `bash` 3.2 compatible.

## Guardrails and tests

- `guard-scaling-ops` now warns on `populate-instance` high counts.
- `guard-destructive-ops` now warns before `cleanup-populated-instance`.
- 3 new guardrail test cases; 38/38 passing.
- `shellcheck -S warning` clean on all three scripts.

## Notes for review

- Draft while @gm3dmo reviews naming and placement (scripts at repo root to match `create-many-*` / `*-report.sh`; docs in the `scale-environment` skill).
- Happy to adjust the confirm-gate host list or the preset counts.
