### PR TITLE
Add REST API scripts for enterprise billing budgets

### DIFF
--- a/create-a-budget.sh
+++ b/create-a-budget.sh
@@ -1,0 +1,46 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#create-a-budget
+# POST /enterprises/{enterprise}/settings/billing/budgets
+
+# Creates a new budget for an enterprise. The authenticated user must be an
+# enterprise admin, organization admin, or billing manager of the enterprise.
+
+# Budget settings (override by editing these values).
+budget_amount=200
+prevent_further_usage="true"
+budget_scope="enterprise"
+budget_entity_name=""
+budget_type="ProductPricing"
+budget_product_sku="actions"
+will_alert="false"
+
+json_file=tmp/create-a-budget.json
+
+jq -n \
+           --argjson budget_amount "${budget_amount}" \
+           --argjson prevent_further_usage "${prevent_further_usage}" \
+           --arg budget_scope "${budget_scope}" \
+           --arg budget_entity_name "${budget_entity_name}" \
+           --arg budget_type "${budget_type}" \
+           --arg budget_product_sku "${budget_product_sku}" \
+           --argjson will_alert "${will_alert}" \
+           '{
+             budget_amount: $budget_amount,
+             prevent_further_usage: $prevent_further_usage,
+             budget_scope: $budget_scope,
+             budget_entity_name: $budget_entity_name,
+             budget_type: $budget_type,
+             budget_product_sku: $budget_product_sku,
+             budget_alerting: {
+               will_alert: $will_alert,
+               alert_recipients: []
+             }
+           }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets" --data @${json_file}

--- a/delete-a-budget-for-an-enterprise.sh
+++ b/delete-a-budget-for-an-enterprise.sh
@@ -1,0 +1,21 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#delete-a-budget
+# DELETE /enterprises/{enterprise}/settings/billing/budgets/{budget_id}
+
+# Deletes a budget by ID. The authenticated user must be an enterprise admin.
+
+# If the script is passed an argument $1 use that as the budget_id
+if [ -z "$1" ]
+  then
+    budget_id=${budget_id}
+  else
+    budget_id=$1
+fi
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets/${budget_id}"

--- a/get-a-budget-by-id-for-an-enterprise.sh
+++ b/get-a-budget-by-id-for-an-enterprise.sh
@@ -1,0 +1,21 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#get-a-budget-by-id
+# GET /enterprises/{enterprise}/settings/billing/budgets/{budget_id}
+
+# Gets a budget by ID. The authenticated user must be an enterprise admin or
+# billing manager.
+
+# If the script is passed an argument $1 use that as the budget_id
+if [ -z "$1" ]
+  then
+    budget_id=${budget_id}
+  else
+    budget_id=$1
+fi
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets/${budget_id}"

--- a/get-all-budgets-for-an-enterprise.sh
+++ b/get-all-budgets-for-an-enterprise.sh
@@ -1,0 +1,13 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#get-all-budgets
+# GET /enterprises/{enterprise}/settings/billing/budgets
+
+# Gets all budgets for an enterprise. The authenticated user must be an
+# enterprise admin or billing manager.
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets"

--- a/get-user-states-for-a-multi-user-budget-for-an-enterprise.sh
+++ b/get-user-states-for-a-multi-user-budget-for-an-enterprise.sh
@@ -1,0 +1,21 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#get-user-states-for-a-multi-user-budget
+# GET /enterprises/{enterprise}/settings/billing/budgets/{budget_id}/user-states
+
+# Lists per-user budget state for a multi-user customer scoped budget. The
+# authenticated user must be an enterprise admin or billing manager.
+
+# If the script is passed an argument $1 use that as the budget_id
+if [ -z "$1" ]
+  then
+    budget_id=${budget_id}
+  else
+    budget_id=$1
+fi
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets/${budget_id}/user-states"

--- a/update-a-budget-for-an-enterprise.sh
+++ b/update-a-budget-for-an-enterprise.sh
@@ -1,0 +1,42 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28#update-a-budget
+# PATCH /enterprises/{enterprise}/settings/billing/budgets/{budget_id}
+
+# Updates an existing budget for an enterprise. The authenticated user must be an
+# enterprise admin, organization admin, or billing manager of the enterprise.
+
+# If the script is passed an argument $1 use that as the budget_id
+if [ -z "$1" ]
+  then
+    budget_id=${budget_id}
+  else
+    budget_id=$1
+fi
+
+# Budget settings to update (override by editing these values).
+budget_amount=10
+prevent_further_usage="false"
+will_alert="false"
+
+json_file=tmp/update-a-budget.json
+
+jq -n \
+           --argjson budget_amount "${budget_amount}" \
+           --argjson prevent_further_usage "${prevent_further_usage}" \
+           --argjson will_alert "${will_alert}" \
+           '{
+             budget_amount: $budget_amount,
+             prevent_further_usage: $prevent_further_usage,
+             budget_alerting: {
+               will_alert: $will_alert,
+               alert_recipients: []
+             }
+           }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X PATCH \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github.v3+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/enterprises/${enterprise}/settings/billing/budgets/${budget_id}" --data @${json_file}


### PR DESCRIPTION
Adds curl example scripts for every endpoint on the [Budgets REST API](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/budgets?apiVersion=2022-11-28) page, following the `skeleton.sh` convention.

| Script | Method | Endpoint |
|---|---|---|
| `get-all-budgets-for-an-enterprise.sh` | GET | `/settings/billing/budgets` |
| `create-a-budget.sh` | POST | `/settings/billing/budgets` |
| `get-a-budget-by-id-for-an-enterprise.sh` | GET | `/settings/billing/budgets/{id}` |
| `update-a-budget-for-an-enterprise.sh` | PATCH | `/settings/billing/budgets/{id}` |
| `delete-a-budget-for-an-enterprise.sh` | DELETE | `/settings/billing/budgets/{id}` |
| `get-user-states-for-a-multi-user-budget-for-an-enterprise.sh` | GET | `/settings/billing/budgets/{id}/user-states` |

Scripts taking a budget ID accept it as `$1` or fall back to `${budget_id}` from `.gh-api-examples.conf`.

Closes #590
