### PR TITLE
Add REST API scripts for user artifact attestations

### DIFF
--- a/delete-attestations-by-id.sh
+++ b/delete-attestations-by-id.sh
@@ -1,0 +1,24 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10#delete-attestations-by-id
+# DELETE /users/{username}/attestations/{attestation_id}
+
+
+# If the script is passed an argument $1 use that as the username
+if [ -z "$1" ]
+  then
+    username=${admin_user}
+  else
+    username=$1
+fi
+
+# The attestation_id is passed as the second argument
+attestation_id=$2
+
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: ******" \
+        "${GITHUB_API_BASE_URL}/users/${username}/attestations/${attestation_id}"

--- a/delete-attestations-by-subject-digest.sh
+++ b/delete-attestations-by-subject-digest.sh
@@ -1,0 +1,24 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10#delete-attestations-by-subject-digest
+# DELETE /users/{username}/attestations/digest/{subject_digest}
+
+
+# If the script is passed an argument $1 use that as the username
+if [ -z "$1" ]
+  then
+    username=${admin_user}
+  else
+    username=$1
+fi
+
+# If the script is passed an argument $2 use that as the subject_digest
+subject_digest=${2:-sha256:abc123}
+
+
+curl ${curl_custom_flags} \
+     -X DELETE \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: ******" \
+        "${GITHUB_API_BASE_URL}/users/${username}/attestations/digest/${subject_digest}"

--- a/delete-attestations-in-bulk.sh
+++ b/delete-attestations-in-bulk.sh
@@ -1,0 +1,31 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10#delete-attestations-in-bulk
+# POST /users/{username}/attestations/delete-request
+
+
+# If the script is passed an argument $1 use that as the username
+if [ -z "$1" ]
+  then
+    username=${admin_user}
+  else
+    username=$1
+fi
+
+
+json_file=tmp/delete-attestations-in-bulk.json
+
+jq -n \
+       --arg digest1 "sha256:abc123" \
+       --arg digest2 "sha512:def456" \
+       '{
+         subject_digests: [ $digest1, $digest2 ]
+       }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: ******" \
+        "${GITHUB_API_BASE_URL}/users/${username}/attestations/delete-request" --data @${json_file}

--- a/list-attestations-by-bulk-subject-digests.sh
+++ b/list-attestations-by-bulk-subject-digests.sh
@@ -1,0 +1,31 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10#list-attestations-by-bulk-subject-digests
+# POST /users/{username}/attestations/bulk-list
+
+
+# If the script is passed an argument $1 use that as the username
+if [ -z "$1" ]
+  then
+    username=${admin_user}
+  else
+    username=$1
+fi
+
+
+json_file=tmp/list-attestations-by-bulk-subject-digests.json
+
+jq -n \
+       --arg digest1 "sha256:abc123" \
+       --arg digest2 "sha512:def456" \
+       '{
+         subject_digests: [ $digest1, $digest2 ]
+       }' > ${json_file}
+
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: ******" \
+        "${GITHUB_API_BASE_URL}/users/${username}/attestations/bulk-list" --data @${json_file}

--- a/list-attestations.sh
+++ b/list-attestations.sh
@@ -1,0 +1,23 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10#list-attestations
+# GET /users/{username}/attestations/{subject_digest}
+
+
+# If the script is passed an argument $1 use that as the username
+if [ -z "$1" ]
+  then
+    username=${admin_user}
+  else
+    username=$1
+fi
+
+# If the script is passed an argument $2 use that as the subject_digest
+subject_digest=${2:-sha256:abc123}
+
+
+curl ${curl_custom_flags} \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: ******" \
+        "${GITHUB_API_BASE_URL}/users/${username}/attestations/${subject_digest}"


### PR DESCRIPTION
Adds curl-based example scripts for the five endpoints in the [users/attestations REST API](https://docs.github.com/en/rest/users/attestations?apiVersion=2026-03-10) (API version 2026-03-10).

| Script | Method | Endpoint |
|---|---|---|
| `list-attestations-by-bulk-subject-digests.sh` | POST | `/users/{username}/attestations/bulk-list` |
| `delete-attestations-in-bulk.sh` | POST | `/users/{username}/attestations/delete-request` |
| `delete-attestations-by-subject-digest.sh` | DELETE | `/users/{username}/attestations/digest/{subject_digest}` |
| `delete-attestations-by-id.sh` | DELETE | `/users/{username}/attestations/{attestation_id}` |
| `list-attestations.sh` | GET | `/users/{username}/attestations/{subject_digest}` |

All scripts follow existing repo conventions: source `.gh-api-examples.conf`, send `X-GitHub-Api-Version: ${github_api_version}` and `Authorization` headers, and default `username` to `admin_user` (overridable via `$1`). The two bulk POST scripts write a placeholder `subject_digests` array to `tmp/` via `jq`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
