### PR TITLE
Fix terraformworkspaceid.py to handle newer gheboot notification format

### DIFF
--- a/terraformworkspaceid.py
+++ b/terraformworkspaceid.py
@@ -4,14 +4,14 @@ import argparse
 import json
 import logging
 import pprint
-import shlex
+import re
 import thepower
 
 
 def terraform_workspace_id(text):
     """Extracts Terraform Workspace ID and write it to JSON.
 
-    Example input:
+    Example input (older gheboot notification format):
 
 @kyanny
 , :wave:
@@ -19,19 +19,19 @@ You've requested GHES 3.10.3 single-node resources in australiaeast on azure wit
 You can follow your instance creation @ https://terraform.githubapp.com/app/ghes/workspaces/gheboot-kyanny-1716187058841/runs/run-PNAKUxRcwBjyNF1T. (If this is your first time launching a GHEBoot instance via Terraform you will need to log into Terraform Enterprise from the Okta tile before this link will work)
 We've set the name of this request to gheboot-kyanny-1716187058841 and your Terraform workspace is: gheboot-kyanny-1716187058841 (ws-v8whx1M2tBoYcNeC) and we've used the key in position 0 in your profile in GitHub.com for SSH access to this instance.
 Just FYI, the reqested instance(s) will expire on 2024-05-22.
+
+    Example input (newer gheboot notification format):
+
+@kyanny, Your gheboot workspace gheboot-kyanny-3-21-3-standalone-0fd7d1e8 has been created with ID ws-K7Km2WgPVYk3GWyG in Terraform Enterprise and is being configured for your GHES instance(s).
     """
 
-    lexer = shlex.shlex(text)
-    lexer.whitespace_split = True
-    lexer.whitespace = ' \t\n\r\f\v'
-    tokens = list(lexer)
+    # Match the ID directly rather than relying on its position relative to
+    # surrounding wording, since the notification wording varies between formats.
+    match = re.search(r"\bws-[A-Za-z0-9]+\b", text)
+    if not match:
+        raise ValueError("Could not find a Terraform workspace ID (ws-XXXX) in the input")
 
-    # Terraform Workspace ID is the token three after "workspace"
-    index = tokens.index("workspace")
-    # Remove the parentheses
-    workspace_id = tokens[index + 3].replace("(", "").replace(")", "")
-
-    return {"terraform_workspace_id": workspace_id}
+    return {"terraform_workspace_id": match.group(0)}
 
 
 def main(args):
@@ -42,12 +42,19 @@ def main(args):
         thepower.clear_screen()
         print(f"\033[93m\n\n{message}\033[0m\n")  
         lines = []
+        empty_line_count = 0
         while True:
             line = input()
             if line:
+                # Reset empty line counter and add any skipped blank lines back
+                for _ in range(empty_line_count):
+                    lines.append('')
+                empty_line_count = 0
                 lines.append(line)
             else:
-                break
+                empty_line_count += 1
+                if empty_line_count >= 2:
+                    break
         text = '\n'.join(lines)
     else:
         # assume the file exists


### PR DESCRIPTION
- Extract the workspace ID via regex (ws-[A-Za-z0-9]+) instead of a fixed token offset from "workspace", which broke when gheboot's notification wording changed.
- Require two consecutive blank lines to end paste input (matching ghe2json.py), since single blank lines between paragraphs caused the script to stop reading early and leak remaining pasted text into the shell.