### PR TITLE
Add security advisory API examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
 # Copilot Instructions
 
 - Always use `python3 base64encode.py` for base64 encoding, never native `base64` CLI tools.
+- Never embed or substitute credentials in scripts. GitHub API authorization headers must reference the configured token variable, for example `-H "Authorization: Bearer ${GITHUB_TOKEN}"`.

--- a/create-a-repository-security-advisory.sh
+++ b/create-a-repository-security-advisory.sh
@@ -1,0 +1,36 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#create-a-repository-security-advisory
+# POST /repos/{owner}/{repo}/security-advisories
+
+repo=${1:-${repo}}
+timestamp=$(date +%s)
+json_file=tmp/create-a-repository-security-advisory.json
+
+jq -n \
+     --arg summary "Security advisory for ${repo} ${timestamp}" \
+     --arg description "A test repository security advisory created by the-power." \
+     --arg package_name "${repo}" \
+     '{
+       summary: $summary,
+       description: $description,
+       severity: "high",
+       vulnerabilities: [
+         {
+           package: {
+             ecosystem: "other",
+             name: $package_name
+           },
+           vulnerable_version_range: "< 1.0.0",
+           patched_versions: "1.0.0"
+         }
+       ],
+       cwe_ids: ["CWE-20"]
+     }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories" --data @${json_file}

--- a/create-a-temporary-private-fork.sh
+++ b/create-a-temporary-private-fork.sh
@@ -1,0 +1,14 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#create-a-temporary-private-fork
+# POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks
+
+ghsa_id=${1:-GHSA_ID}
+repo=${2:-${repo}}
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories/${ghsa_id}/forks"

--- a/enable-private-vulnerability-reporting-for-a-repository.sh
+++ b/enable-private-vulnerability-reporting-for-a-repository.sh
@@ -1,0 +1,13 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository
+# PUT /repos/{owner}/{repo}/private-vulnerability-reporting
+
+repo=${1:-${repo}}
+
+curl ${curl_custom_flags} \
+     -X PUT \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/private-vulnerability-reporting"

--- a/get-a-global-security-advisory.sh
+++ b/get-a-global-security-advisory.sh
@@ -1,0 +1,13 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/global-advisories?apiVersion=2026-03-10#get-a-global-security-advisory
+# GET /advisories/{ghsa_id}
+
+ghsa_id=${1:-GHSA_ID}
+
+curl ${curl_custom_flags} \
+     -X GET \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/advisories/${ghsa_id}"

--- a/get-a-repository-security-advisory.sh
+++ b/get-a-repository-security-advisory.sh
@@ -1,0 +1,14 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#get-a-repository-security-advisory
+# GET /repos/{owner}/{repo}/security-advisories/{ghsa_id}
+
+ghsa_id=${1:-GHSA_ID}
+repo=${2:-${repo}}
+
+curl ${curl_custom_flags} \
+     -X GET \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories/${ghsa_id}"

--- a/list-global-security-advisories.sh
+++ b/list-global-security-advisories.sh
@@ -1,0 +1,11 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/global-advisories?apiVersion=2026-03-10#list-global-security-advisories
+# GET /advisories
+
+curl ${curl_custom_flags} \
+     -X GET \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/advisories"

--- a/list-repository-security-advisories-for-an-organization.sh
+++ b/list-repository-security-advisories-for-an-organization.sh
@@ -1,0 +1,11 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#list-repository-security-advisories-for-an-organization
+# GET /orgs/{org}/security-advisories
+
+curl ${curl_custom_flags} \
+     -X GET \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/orgs/${org}/security-advisories"

--- a/list-repository-security-advisories.sh
+++ b/list-repository-security-advisories.sh
@@ -1,0 +1,13 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#list-repository-security-advisories
+# GET /repos/{owner}/{repo}/security-advisories
+
+repo=${1:-${repo}}
+
+curl ${curl_custom_flags} \
+     -X GET \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories"

--- a/privately-report-a-security-vulnerability.sh
+++ b/privately-report-a-security-vulnerability.sh
@@ -1,0 +1,36 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#privately-report-a-security-vulnerability
+# POST /repos/{owner}/{repo}/security-advisories/reports
+
+repo=${1:-${repo}}
+timestamp=$(date +%s)
+json_file=tmp/privately-report-a-security-vulnerability.json
+
+jq -n \
+     --arg summary "Private vulnerability report for ${repo} ${timestamp}" \
+     --arg description "A test private vulnerability report created by the-power." \
+     --arg package_name "${repo}" \
+     '{
+       summary: $summary,
+       description: $description,
+       severity: "high",
+       vulnerabilities: [
+         {
+           package: {
+             ecosystem: "other",
+             name: $package_name
+           },
+           vulnerable_version_range: "< 1.0.0",
+           patched_versions: "1.0.0"
+         }
+       ],
+       cwe_ids: ["CWE-20"]
+     }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories/reports" --data @${json_file}

--- a/request-a-cve-for-a-repository-security-advisory.sh
+++ b/request-a-cve-for-a-repository-security-advisory.sh
@@ -1,0 +1,14 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#request-a-cve-for-a-repository-security-advisory
+# POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/cve
+
+ghsa_id=${1:-GHSA_ID}
+repo=${2:-${repo}}
+
+curl ${curl_custom_flags} \
+     -X POST \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories/${ghsa_id}/cve"

--- a/update-a-repository-security-advisory.sh
+++ b/update-a-repository-security-advisory.sh
@@ -1,0 +1,21 @@
+.  ./.gh-api-examples.conf
+
+# https://docs.github.com/en/rest/security-advisories/repository-advisories?apiVersion=2026-03-10#update-a-repository-security-advisory
+# PATCH /repos/{owner}/{repo}/security-advisories/{ghsa_id}
+
+ghsa_id=${1:-GHSA_ID}
+repo=${2:-${repo}}
+json_file=tmp/update-a-repository-security-advisory.json
+
+jq -n \
+     '{
+       severity: "critical",
+       state: "draft"
+     }' > ${json_file}
+
+curl ${curl_custom_flags} \
+     -X PATCH \
+     -H "X-GitHub-Api-Version: ${github_api_version}" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/security-advisories/${ghsa_id}" --data @${json_file}


### PR DESCRIPTION
## Summary
- add REST API examples for global and repository security advisories
- add private vulnerability reporting and temporary fork examples
- document the configured-token requirement for authorization headers